### PR TITLE
test_crashes.cpp - Fix compiler error (Ubuntu22.04), unable to deduce…

### DIFF
--- a/tests/instructions/test_crashes.cpp
+++ b/tests/instructions/test_crashes.cpp
@@ -55,7 +55,7 @@ void execute(uint64_t max_mem, const char* array_name,
 		{
 			// Make available on machine
 			machine.cpu.init_execute_area(data, 0x1000, len);
-			auto* seg = machine.cpu.current_execute_segment();
+			auto &seg = machine.cpu.current_execute_segment();
 
 			// Also, make the instructions readable & executable
 			machine.copy_to_guest(0x1000, data, len);

--- a/tests/instructions/testable_instruction.hpp
+++ b/tests/instructions/testable_instruction.hpp
@@ -25,12 +25,14 @@ namespace riscv
 			insn.bits
 		};
 
-		machine.cpu.init_execute_area(&instr_page[0], MEMBASE, sizeof(instr_page));
+		DecodedExecuteSegment<W> &des = machine.cpu.init_execute_area(&instr_page[0], MEMBASE, sizeof(instr_page));
 		// jump to page containing instruction
 		machine.cpu.jump(MEMBASE);
 		// execute instruction
 		machine.cpu.reg(insn.reg) = insn.initial_value;
 		machine.cpu.step_one();
+		// There is a max number of execute segments. Evict the latest to avoid the max limit check
+		machine.cpu.memory().evict_execute_segment(des);
 		// call instruction validation callback
 		if ( callback(machine.cpu, insn) ) return true;
 		fprintf(stderr, "Failed test: %s on iteration %d\n", insn.name, insn.index);


### PR DESCRIPTION
I found a couple of issues compiling and running tests/instructions. I am using Ubuntu22.04.

test_crashes.cpp:

31: error: unable to deduce ‘auto*’ from ‘machine.riscv::Machine<4>::cpu.riscv::CPU<4>::current_execute_segment()’
   58 |                         auto* seg = machine.cpu.current_execute_segment();
      |                               ^~~

testable_instruction.hpp:
* Testing crash_983d2079843182f2cb27e6aeeb47af256c44fcdd
* Testing crash_983d2079843182f2cb27e6aeeb47af256c44fcdd
* Testing timeout_1a6dbaa717f8837c4bd4332121e92bd73bbec049
* Testing timeout_1a6dbaa717f8837c4bd4332121e92bd73bbec049
* Test RV32I
* Test RV32C
terminate called after throwing an instance of 'riscv::MachineException'
  what():  Max execute segments reached
Aborted