### PR TITLE
Fix compilation on macos

### DIFF
--- a/lib/libriscv/linux/syscalls_mman.cpp
+++ b/lib/libriscv/linux/syscalls_mman.cpp
@@ -1,7 +1,7 @@
 /// Linux memory mapping system call emulation
 /// Works on all platforms
-#define MAP_ANONYMOUS        0x20
-#define MAP_NORESERVE     0x04000
+#define LINUX_MAP_ANONYMOUS        0x20
+#define LINUX_MAP_NORESERVE     0x04000
 
 template <int W>
 static void add_mman_syscalls()
@@ -139,11 +139,11 @@ static void add_mman_syscalls()
 		}
 
 		// anon pages need to be zeroed
-		if (flags & MAP_ANONYMOUS) {
+		if (flags & LINUX_MAP_ANONYMOUS) {
 			machine.memory.memdiscard(result, length, true);
 		}
 		// avoid potentially creating pages when MAP_NORESERVE is set
-		if ((flags & MAP_NORESERVE) == 0)
+		if ((flags & LINUX_MAP_NORESERVE) == 0)
 		{
 			machine.memory.set_page_attr(result, length, attr);
 		}

--- a/lib/libriscv/linux/system_calls.cpp
+++ b/lib/libriscv/linux/system_calls.cpp
@@ -34,7 +34,7 @@ extern "C" int dup3(int oldfd, int newfd, int flags);
 #ifndef EBADFD
 #define EBADFD EBADF  // OpenBSD, FreeBSD
 #endif
-#define SA_ONSTACK	0x08000000
+#define LINUX_SA_ONSTACK	0x08000000
 
 namespace riscv {
 template <int W>
@@ -145,14 +145,14 @@ static void syscall_sigaction(Machine<W>& machine)
 	} sa {};
 	if (old_action != 0x0) {
 		sa.sa_handler = sigact.handler & ~address_type<W>(0xF);
-		sa.sa_flags   = (sigact.altstack ? SA_ONSTACK : 0x0);
+		sa.sa_flags   = (sigact.altstack ? LINUX_SA_ONSTACK : 0x0);
 		sa.sa_mask    = sigact.mask;
 		machine.copy_to_guest(old_action, &sa, sizeof(sa));
 	}
 	if (action != 0x0) {
 		machine.copy_from_guest(&sa, action, sizeof(sa));
 		sigact.handler  = sa.sa_handler;
-		sigact.altstack = (sa.sa_flags & SA_ONSTACK) != 0;
+		sigact.altstack = (sa.sa_flags & LINUX_SA_ONSTACK) != 0;
 		sigact.mask     = sa.sa_mask;
 		SYSPRINT("<<< sigaction %d handler: 0x%lX altstack: %d\n",
 			sig, (long)sigact.handler, sigact.altstack);
@@ -523,6 +523,9 @@ static void syscall_dup3(Machine<W>& machine)
 		}
 		machine.set_result_or_error(res);
 #else
+		(void)flags;
+		(void)real_old_fd;
+		(void)real_new_fd;
 		machine.set_result(-ENOSYS);
 #endif
 	} else {


### PR DESCRIPTION
`MAP_ANONYMOUS` and `MAP_NORESERVE` are already defined when building on macos, but they have different values so the compilation fails. There was a similar issue with `SA_ONSTACK` which is also already defined (with a different value).