### PR TITLE
Allow storing shared options in Machine, optionally

### DIFF
--- a/emulator/src/main.cpp
+++ b/emulator/src/main.cpp
@@ -250,8 +250,7 @@ static void run_program(
 		cc.push_back(riscv::MachineTranslationEmbeddableCodeOptions{cli_args.output_file});
 	}
 
-	// Create a RISC-V machine with the binary as input program
-	riscv::Machine<W> machine { binary, {
+	auto options = std::make_shared<riscv::MachineOptions<W>>(riscv::MachineOptions<W>{
 		.memory_max = MAX_MEMORY,
 		.enforce_exec_only = cli_args.execute_only,
 		.ignore_text_section = cli_args.ignore_text,
@@ -284,7 +283,15 @@ static void run_program(
 		.cross_compile = cc,
 #endif
 #endif
-	}};
+	});
+
+	// Create a RISC-V machine with the binary as input program
+	riscv::Machine<W> machine { binary, *options };
+
+	// Remember the options for later in case background compilation is enabled,
+	// if new execute segments need to be decoded and so on. Basically all future
+	// operations that need to know the options. This is optional.
+	machine.set_options(std::move(options));
 
 	if (cli_args.quit) { // Quit after instantiating the machine
 		return;

--- a/lib/libriscv/cpu.cpp
+++ b/lib/libriscv/cpu.cpp
@@ -78,8 +78,12 @@ namespace riscv
 		if (vlength < 4)
 			trigger_exception(EXECUTION_SPACE_PROTECTION_FAULT, begin);
 		// Create a new *non-initial* execute segment
-		this->m_exec = &machine().memory.create_execute_segment(
-			machine().options(), vdata, begin, vlength, false, is_likely_jit);
+		if (machine().has_options())
+			this->m_exec = &machine().memory.create_execute_segment(
+				machine().options(), vdata, begin, vlength, false, is_likely_jit);
+		else
+			this->m_exec = &machine().memory.create_execute_segment(
+				MachineOptions<W>(), vdata, begin, vlength, false, is_likely_jit);
 		return *this->m_exec;
 	} // CPU::init_execute_area
 

--- a/lib/libriscv/machine.cpp
+++ b/lib/libriscv/machine.cpp
@@ -29,8 +29,7 @@ namespace riscv
 	inline Machine<W>::Machine(std::string_view binary, const MachineOptions<W>& options)
 		: cpu(*this, options.cpu_id),
 		  memory(*this, binary, options),
-		  m_arena(nullptr),
-		  m_options(options)
+		  m_arena(nullptr)
 	{
 		cpu.reset();
 	}
@@ -38,8 +37,7 @@ namespace riscv
 	inline Machine<W>::Machine(const Machine& other, const MachineOptions<W>& options)
 		: cpu(*this, options.cpu_id, other),
 		  memory(*this, other, options),
-		  m_arena(nullptr),
-		  m_options(options)
+		  m_arena(nullptr)
 	{
 		this->m_counter = other.m_counter;
 		this->m_max_counter = other.m_max_counter;
@@ -52,8 +50,8 @@ namespace riscv
 	template <int W>
 	inline Machine<W>::Machine(const std::vector<uint8_t>& bin, const MachineOptions<W>& opts)
 		: Machine(std::string_view{(char*) bin.data(), bin.size()}, opts) {}
-	template <int W>
 
+	template <int W>
 	inline Machine<W>::Machine(const MachineOptions<W>& opts)
 		: Machine(std::string_view{}, opts){}
 

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -66,10 +66,16 @@ namespace riscv
 		/// @brief Tears down the machine, freeing all owned memory and pages.
 		~Machine();
 
+		/// @brief Returns true if the machine has MachineOptions set.
+		/// @return True if the machine has options.
+		bool has_options() const noexcept { return m_options != nullptr; }
+		/// @brief Set the machine options that will be used for future forked machines and execute segments.
+		/// @param opts The machine options.
+		void set_options(std::shared_ptr<MachineOptions<W>> opts) noexcept { m_options = std::move(opts); }
 		/// @brief Returns the machine options that were used to create the machine.
 		/// @return The machine options.
-		auto& options() const noexcept { return m_options; }
-		auto& options() noexcept { return m_options; }
+		MachineOptions<W>& options() const;
+		MachineOptions<W>& options();
 
 		/// @brief Simulate RISC-V starting from the PC register, and
 		/// stopping when at most @max_instructions have been executed.
@@ -379,7 +385,7 @@ namespace riscv
 
 		/// @brief Check if the machine has enforced and loaded an execute-only program.
 		/// @return True if all execute segments are execute-only.
-		bool is_execute_only() const noexcept { return options().enforce_exec_only; }
+		bool is_execute_only() const noexcept { if (!has_options()) return false; else return options().enforce_exec_only; }
 
 		// Optional custom native-performance arena
 		bool has_arena() const noexcept { return m_arena != nullptr; }
@@ -465,6 +471,7 @@ namespace riscv
 		std::unique_ptr<FileDescriptors> m_fds = nullptr;
 		std::unique_ptr<Multiprocessing<W>> m_smp = nullptr;
 		std::unique_ptr<Signals<W>> m_signals = nullptr;
+		std::shared_ptr<MachineOptions<W>> m_options = nullptr;
 
 #ifdef RISCV_TIMED_VMCALLS
 	public:
@@ -473,8 +480,6 @@ namespace riscv
 		void disable_timer();
 		void* m_timer_id = nullptr;
 #endif
-
-		MachineOptions<W> m_options;
 
 		static_assert((W == 4 || W == 8 || W == 16), "Must be either 32-bit, 64-bit or 128-bit ISA");
 		static void default_printer(const Machine&, const char*, size_t);

--- a/lib/libriscv/machine_inline.hpp
+++ b/lib/libriscv/machine_inline.hpp
@@ -300,4 +300,27 @@ Signals<W>& Machine<W>::signals() {
 	return *m_signals;
 }
 
+template <int W> inline
+MachineOptions<W>& Machine<W>::options() const
+{
+	if (m_options == nullptr)
+#if __cpp_exceptions
+		throw MachineException(ILLEGAL_OPERATION, "Machine options have not been set/initialized");
+#else
+	std::abort();
+#endif
+	return *m_options;
+}
+template <int W> inline
+MachineOptions<W>& Machine<W>::options()
+{
+	if (m_options == nullptr)
+#if __cpp_exceptions
+		throw MachineException(ILLEGAL_OPERATION, "Machine options have not been set/initialized");
+#else
+	std::abort();
+#endif
+	return *m_options;
+}
+
 #include "machine_vmcall.hpp"


### PR DESCRIPTION
This saves 104 bytes per machine, and still allows many strategies for sharing options between machines.
