### PR TITLE
Remove unused RV32C_BC_JUMPFUNC bytecode

### DIFF
--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -758,16 +758,6 @@ INSTRUCTION(RV32C_BC_ANDI, rv32c_andi) {
 	REG(fi.get_rs1()) &= fi.signed_imm();
 	NEXT_C_INSTR();
 }
-INSTRUCTION(RV32C_BC_JUMPFUNC, rv32c_jumpfunc) {
-	REGISTERS().pc = pc;
-	CPU().execute(DECODER().m_handler, DECODER().instr);
-	if constexpr (VERBOSE_JUMPS) {
-		fprintf(stderr, "Compressed jump from 0x%lX to 0x%lX\n",
-			long(pc), long(REGISTERS().pc + 2));
-	}
-	pc = REGISTERS().pc + 2;
-	OVERFLOW_CHECKED_JUMP();
-}
 INSTRUCTION(RV32C_BC_FUNCTION, rv32c_func) {
 	CPU().execute(DECODER().m_handler, DECODER().instr);
 	NEXT_C_INSTR();

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -331,7 +331,6 @@ namespace riscv
 		[RV32C_BC_ANDI]     = rv32c_andi,
 		[RV32C_BC_XOR]      = rv32c_xor,
 		[RV32C_BC_FUNCTION] = rv32c_func,
-		[RV32C_BC_JUMPFUNC] = rv32c_jumpfunc,
 #endif
 
 		[RV32I_BC_SYSCALL] = rv32i_syscall,

--- a/lib/libriscv/threaded_bytecode_array.hpp
+++ b/lib/libriscv/threaded_bytecode_array.hpp
@@ -99,7 +99,6 @@ static constexpr void *computed_opcode[] = {
 	[RV32C_BC_ANDI] = &&rv32c_andi,
 	[RV32C_BC_XOR]  = &&rv32c_xor,
 	[RV32C_BC_FUNCTION] = &&rv32c_func,
-	[RV32C_BC_JUMPFUNC] = &&rv32c_jumpfunc,
 #endif
 
 	[RV32I_BC_SYSCALL] = &&rv32i_syscall,

--- a/lib/libriscv/threaded_bytecodes.hpp
+++ b/lib/libriscv/threaded_bytecodes.hpp
@@ -108,7 +108,6 @@ namespace riscv
 		RV32C_BC_ANDI,
 		RV32C_BC_XOR,
 		RV32C_BC_FUNCTION,
-		RV32C_BC_JUMPFUNC,
 #endif
 
 		RV32I_BC_SYSCALL,

--- a/lib/libriscv/threaded_rewriter.cpp
+++ b/lib/libriscv/threaded_rewriter.cpp
@@ -419,7 +419,8 @@ namespace riscv
 
 				if (!this->is_within(addr, 4) || (addr % PCAL) != 0)
 				{
-					return RV32C_BC_JUMPFUNC;
+					// Allow branch outside of execute segment?
+					return RV32I_BC_INVALID; // No, just return invalid
 				}
 
 				FasterItype rewritten;


### PR DESCRIPTION
This bytecode is from an old, forgotten time