### PR TITLE
Add bytecodes for C.ADD and C.OR

### DIFF
--- a/binaries/show_instructions.sh
+++ b/binaries/show_instructions.sh
@@ -1,1 +1,1 @@
-riscv32-unknown-elf-objdump -d -M no-aliases $1 | awk '{ print $3 }' | sort -n | uniq -c | sort -h
+riscv32-unknown-elf-objdump -d -M no-aliases "$1" | awk '{ print $3 }' | sort -n | uniq -c | sort -h

--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -748,9 +748,19 @@ INSTRUCTION(RV32C_BC_SRLI, rv32c_srli) {
 	REG(fi.get_rs1()) >>= fi.imm;
 	NEXT_C_INSTR();
 }
+INSTRUCTION(RV32C_BC_ADD, rv32c_add) {
+	VIEW_INSTR_AS(fi, FasterItype);
+	REG(fi.get_rs1()) += REG(fi.get_rs2());
+	NEXT_C_INSTR();
+}
 INSTRUCTION(RV32C_BC_XOR, rv32c_xor) {
 	VIEW_INSTR_AS(fi, FasterItype);
 	REG(fi.get_rs1()) ^= REG(fi.get_rs2());
+	NEXT_C_INSTR();
+}
+INSTRUCTION(RV32C_BC_OR, rv32c_or) {
+	VIEW_INSTR_AS(fi, FasterItype);
+	REG(fi.get_rs1()) |= REG(fi.get_rs2());
 	NEXT_C_INSTR();
 }
 INSTRUCTION(RV32C_BC_ANDI, rv32c_andi) {

--- a/lib/libriscv/decode_bytecodes.cpp
+++ b/lib/libriscv/decode_bytecodes.cpp
@@ -144,7 +144,7 @@ size_t CPU<W>::computed_index_for(rv32i_instruction instr) noexcept
 					case 0x1:
 						return RV32C_BC_XOR; // C.XOR
 					case 0x2:
-						return RV32C_BC_FUNCTION; // C.OR
+						return RV32C_BC_OR; // C.OR
 					case 0x3:
 						return RV32C_BC_FUNCTION; // C.AND
 					default:
@@ -170,7 +170,7 @@ size_t CPU<W>::computed_index_for(rv32i_instruction instr) noexcept
 				}
 				else if (ci.CR.rd != 0)
 				{	// ADD rd, rd + rs2
-					return RV32C_BC_FUNCTION; // C.ADD
+					return RV32C_BC_ADD; // C.ADD
 				}
 				else if (topbit && ci.CR.rd == 0 && ci.CR.rs2 == 0)
 				{	// EBREAK

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -329,7 +329,9 @@ namespace riscv
 		[RV32C_BC_STD]      = rv32c_std,
 		[RV32C_BC_SRLI]     = rv32c_srli,
 		[RV32C_BC_ANDI]     = rv32c_andi,
+		[RV32C_BC_ADD]      = rv32c_add,
 		[RV32C_BC_XOR]      = rv32c_xor,
+		[RV32C_BC_OR]       = rv32c_or,
 		[RV32C_BC_FUNCTION] = rv32c_func,
 #endif
 

--- a/lib/libriscv/threaded_bytecode_array.hpp
+++ b/lib/libriscv/threaded_bytecode_array.hpp
@@ -97,7 +97,9 @@ static constexpr void *computed_opcode[] = {
 	[RV32C_BC_STD] = &&rv32c_std,
 	[RV32C_BC_SRLI] = &&rv32c_srli,
 	[RV32C_BC_ANDI] = &&rv32c_andi,
+	[RV32C_BC_ADD]  = &&rv32c_add,
 	[RV32C_BC_XOR]  = &&rv32c_xor,
+	[RV32C_BC_OR]   = &&rv32c_or,
 	[RV32C_BC_FUNCTION] = &&rv32c_func,
 #endif
 

--- a/lib/libriscv/threaded_bytecodes.hpp
+++ b/lib/libriscv/threaded_bytecodes.hpp
@@ -106,7 +106,9 @@ namespace riscv
 		RV32C_BC_STD,
 		RV32C_BC_SRLI,
 		RV32C_BC_ANDI,
+		RV32C_BC_ADD,
 		RV32C_BC_XOR,
+		RV32C_BC_OR,
 		RV32C_BC_FUNCTION,
 #endif
 

--- a/lib/libriscv/threaded_rewriter.cpp
+++ b/lib/libriscv/threaded_rewriter.cpp
@@ -400,7 +400,18 @@ namespace riscv
 				instr.whole = rewritten.whole;
 				return bytecode;
 			}
-			case RV32C_BC_XOR: {
+			case RV32C_BC_ADD: {
+				const rv32c_instruction ci{instr};
+
+				FasterItype rewritten;
+				rewritten.rs1 = ci.CR.rd;
+				rewritten.rs2 = ci.CR.rs2;
+
+				instr.whole = rewritten.whole;
+				return bytecode;
+			}
+			case RV32C_BC_XOR:
+			case RV32C_BC_OR: {
 				const rv32c_instruction ci{instr};
 
 				FasterItype rewritten;


### PR DESCRIPTION
These instructions are showing more usage compared to before, so add them to fast-path