### PR TITLE
Add support for binary translation to string

### DIFF
--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -65,6 +65,11 @@ namespace riscv
 		/// @brief Provide a filename suffix for the embedded code output.
 		/// @example ".c" or ".cpp"
 		std::string suffix = ".cpp";
+
+		/// @brief An optional std::string pointer to write the output code to,
+		/// instead of writing to a file.
+		/// @details Puts freestanding C99 code into the std::string pointer.
+		std::string* result_c99 = nullptr;
 	};
 	using MachineTranslationOptions = std::variant<MachineTranslationCrossOptions, MachineTranslationEmbeddableCodeOptions>;
 


### PR DESCRIPTION
This makes it possible to avoid the local filesystem and just get the translated program directly as a string of freestanding C99.
