### PR TITLE
Fix linking static builds to dynamic libraries on Linux x86_64

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -187,7 +187,7 @@ target_include_directories(riscv PUBLIC .)
 target_include_directories(riscv PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 if (NOT WIN32 OR MINGW_TOOLCHAIN)
-	target_compile_options(riscv PRIVATE -Wall -Wextra)
+	target_compile_options(riscv PRIVATE -Wall -Wextra -fPIC)
 endif()
 
 if (RISCV_EXPERIMENTAL AND RISCV_ENCOMPASSING_ARENA)


### PR DESCRIPTION
I spent way too long trying to figure out why I kept getting relocation errors on my project until I tried adding `-fPIC` to my libriscv build, which fixed the errors. However, this does not to be appear to be already enabled in any case, so that's what this PR fixes.