### PR TITLE
Don't push pre-loaded program headers on the stack

### DIFF
--- a/lib/libriscv/elf.hpp
+++ b/lib/libriscv/elf.hpp
@@ -17,6 +17,8 @@ namespace riscv
 
 		static constexpr uint32_t PT_LOAD    = 1;
 		static constexpr uint32_t PT_DYNAMIC = 2;
+		static constexpr uint32_t PT_PHDR	 = 6;
+		static constexpr uint32_t PT_GNU_EH_FRAME = 0x6474e550;
 		static constexpr uint32_t PT_GNU_STACK = 0x6474e551;
 		static constexpr uint32_t PT_GNU_RELRO = 0x6474e552;
 


### PR DESCRIPTION
This fixes an issue with musl libc that uses PT_PHDR in order to find the image base. It's now possible to handle C++ exceptions with musl+libc++.