### PR TITLE
Simplify TCC build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:latest
 RUN apt update && apt install -y \
 	cmake git \
 	clang-18 \
-	tcc libtcc-dev \
 	g++-13-riscv64-linux-gnu
 
 ENV CXX=clang++-18
@@ -16,7 +15,7 @@ COPY binaries/measure_mips/fib.c /app/emulator/fib.c
 
 # Fast emulation (with TCC JIT compilation)
 WORKDIR /app/emulator
-RUN ./build.sh -x --tcc && cp .build/rvlinux /app/rvlinux && cp .build/libtcc1.a /app/libtcc1.a
+RUN ./build.sh -x --tcc && cp .build/rvlinux /app/rvlinux
 
 # Fastest emulator (with binary translation)
 WORKDIR /app/emulator

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -158,19 +158,7 @@ endif()
 # Generate the settings header
 # RISCV_VERSION_MAJOR and RISCV_VERSION_MINOR are required by libriscv_settings.h.in
 configure_file(libriscv_settings.h.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv_settings.h)
-if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
-	option(RISCV_LIBTCC_DISTRO_PACKAGE "Use the distributions libtcc" OFF)
-
-	if (RISCV_LIBTCC_DISTRO_PACKAGE)
-		message(STATUS "libriscv: Using libtcc from distribution package")
-		configure_file(libriscv_libtcc_distro.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
-	else()
-		message(STATUS "libriscv: Using libtcc from remote repository")
-		configure_file(libriscv_libtcc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
-	endif()
-else()
-	configure_file(libriscv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
-endif()
+configure_file(libriscv.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc)
 
 add_library(riscv ${SOURCES})
 if (COSMOPOLITAN)
@@ -222,33 +210,36 @@ endif()
 
 
 if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
-	if(CMAKE_VERSION VERSION_LESS "3.14.0" OR RISCV_LIBTCC_DISTRO_PACKAGE) 
-		target_link_libraries(riscv PUBLIC -ltcc)
-		set_source_files_properties(libriscv/tr_tcc.cpp PROPERTIES
-			COMPILE_DEFINITIONS RISCV_LIBTCC_PACKAGE=1)
-		set(LIBTCC_FROM_PACKAGE TRUE)
-	else()
-		include(FetchContent)
-		FetchContent_Declare(
-			libtcc
-			GIT_REPOSITORY    https://github.com/fwsGonzo/libtcc-cmake
-			GIT_TAG           master
-		)
-		FetchContent_MakeAvailable(libtcc)
-		target_compile_definitions(libtcc PUBLIC LIBTCC1_NAME="libtcc1.a")
-		if (BUILD_SHARED_LIBS)
-			target_compile_options(libtcc PRIVATE -fPIC)
-		endif()
-		target_link_libraries(riscv PUBLIC libtcc libtcc1)
-		set(LIBTCC_FROM_PACKAGE FALSE)
+	enable_language(C)
+	include(FetchContent)
+	FetchContent_Declare(tinycc
+		GIT_REPOSITORY https://github.com/fwsGonzo/tinycc.git
+		GIT_TAG        mob
+	)
+	FetchContent_MakeAvailable(tinycc)
 
-		# Installed version will need to find libtcc
-		if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
-			target_compile_definitions(riscv PUBLIC
-				LIBTCC_LIBRARY_PATH="/usr/lib/libriscv"
-			)
-		endif()
-	endif()
+	set(TINYCC_LOCATION    "${CMAKE_BINARY_DIR}/_deps/tinycc-src")
+	set(CONFIG_H_LOCATION "${TINYCC_LOCATION}/config.h")
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CONFIG_H_LOCATION})
+	set_source_files_properties(${CONFIG_H_LOCATION} PROPERTIES GENERATED TRUE)
+	file(COPY "${TINYCC_LOCATION}/libtcc.h" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+	file(COPY "${TINYCC_LOCATION}/libtcc1.h" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+
+	target_sources(riscv PRIVATE
+		${tinycc_SOURCE_DIR}/libtcc.c
+		${tinycc_SOURCE_DIR}/libtcc.h
+		${CONFIG_H_LOCATION}
+	)
+	target_compile_definitions(riscv PRIVATE
+		CONFIG_TCC_PREDEFS=1
+		TARGETOS_Linux=1
+		TCC_VERSION="0.9.27"
+		TCC_IS_NATIVE=1
+		TCC_TARGET_X86_64=1
+	)
+	target_include_directories(riscv PUBLIC
+		"${CMAKE_CURRENT_BINARY_DIR}"
+	)
 endif()
 
 if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
@@ -314,14 +305,4 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "libriscv")
 		FILES ${CMAKE_CURRENT_BINARY_DIR}/libriscv.pc
 		DESTINATION lib/pkgconfig
 	)
-	if (RISCV_BINARY_TRANSLATION AND RISCV_LIBTCC)
-		# Install our own copy of libtcc, if we're not using the system package
-		if (NOT LIBTCC_FROM_PACKAGE)
-			install(FILES
-				${CMAKE_BINARY_DIR}/_deps/libtcc-build/libtcc.a
-				${CMAKE_BINARY_DIR}/libtcc1.a
-				DESTINATION lib/${PROJECT_NAME}
-			)
-		endif()
-	endif()
 endif()

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -1,0 +1,4 @@
+#define TCC_TARGET_X86_64 1
+#define TARGETOS_Linux 1
+#define TCC_VERSION "0.9.27"
+#define CONFIG_TCC_PREDEFS 1

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -582,7 +582,7 @@ inline void Emitter<W>::emit_system_call(const std::string& syscall_reg)
 		static constexpr int SYSCALL_TKILL        = 130;
 		static constexpr int SYSCALL_TGKILL       = 131;
 		// There may be more, but these are known to clobber all registers
-		static constexpr std::array<int, 9> clobbering_syscalls = {
+		[[maybe_unused]] static constexpr std::array<int, 9> clobbering_syscalls = {
 			SYSCALL_CLONE,
 			SYSCALL_CLONE3,
 			SYSCALL_SCHED_YIELD,

--- a/lib/libriscv/tr_tcc.cpp
+++ b/lib/libriscv/tr_tcc.cpp
@@ -1,19 +1,16 @@
 #include "common.hpp"
 
-#ifdef RISCV_LIBTCC_PACKAGE
-# include <libtcc.h>
-#else
-# include <tcc/libtcc.h>
-# ifndef LIBTCC_LIBRARY_PATH
-#  define LIBTCC_LIBRARY_PATH "."
-# endif
-#endif
+#include <cstring>
+#include <libtcc.h>
+#include <libtcc1.h> // libtcc1_c and libtcc1_c_len
 
 namespace riscv
 {
 	void* libtcc_compile(const std::string& code,
 		int, const std::unordered_map<std::string, std::string>& cflags, const std::string& libtcc1)
 	{
+		(void)libtcc1;
+
 		TCCState* state = tcc_new();
 		if (!state)
 			return nullptr;
@@ -25,29 +22,31 @@ namespace riscv
 		}
 
 		tcc_define_symbol(state, "ARCH", "HOST_UNKNOWN");
-		tcc_set_options(state, "-std=c99 -O2");
+		tcc_set_options(state, "-std=c99 -O2 -nostdlib");
 
 #ifdef _WIN32
 		// Look for some headers in the win32 directory
 		tcc_add_include_path(state, "win32");
 #endif
 
-		if (!libtcc1.empty())
-			tcc_add_library_path(state, libtcc1.c_str());
-#ifdef LIBTCC_LIBRARY_PATH
-		tcc_add_library_path(state, LIBTCC_LIBRARY_PATH);
-#endif
+		tcc_add_symbol(state, "memset", (void*)memset);
+		tcc_add_symbol(state, "memcpy", (void*)memcpy);
+		tcc_add_symbol(state, "memcmp", (void*)memcmp);
+		tcc_add_symbol(state, "memmove", (void*)memmove);
 
-		if (tcc_compile_string(state, code.c_str()) < 0) {
+		std::string code1 = std::string((const char*)lib_libtcc1_c, lib_libtcc1_c_len) + code;
+
+		if (tcc_compile_string(state, code1.c_str()) < 0) {
 			tcc_delete(state);
 			return nullptr;
 		}
 
 #if defined(TCC_RELOCATE_AUTO)
-		if (tcc_relocate(state, TCC_RELOCATE_AUTO) < 0) {
+		if (tcc_relocate(state, TCC_RELOCATE_AUTO) < 0)
 #else
-		if (tcc_relocate(state) < 0) {
+		if (tcc_relocate(state) < 0)
 #endif
+		{
 			tcc_delete(state);
 			return nullptr;
 		}

--- a/lib/libriscv_libtcc.pc.in
+++ b/lib/libriscv_libtcc.pc.in
@@ -1,6 +1,0 @@
-Name: @CMAKE_PROJECT_NAME@
-Description: @CMAKE_PROJECT_DESCRIPTION@
-URL: https://github.com/fwsGonzo/libriscv
-Version: @PROJECT_VERSION@
-Cflags: -I/usr/include
-Libs: -L/usr/lib -lriscv -l:libriscv/libtcc.a

--- a/lib/libriscv_libtcc_distro.pc.in
+++ b/lib/libriscv_libtcc_distro.pc.in
@@ -1,6 +1,0 @@
-Name: @CMAKE_PROJECT_NAME@
-Description: @CMAKE_PROJECT_DESCRIPTION@
-URL: https://github.com/fwsGonzo/libriscv
-Version: @PROJECT_VERSION@
-Cflags: -I/usr/include
-Libs: -L/usr/lib -lriscv -l:libtcc.a


### PR DESCRIPTION
This is an attempt at simplifying TCC code generation by creating custom build scripts for it that pulls and only builds libtcc. The previous libtcc-cmake repository is overly complex.