### PR TITLE
Remove experimental timed VM calls

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -113,16 +113,13 @@ _libriscv_ is primarily configured using CMake options:
 > RISCV_ENCOMPASSING_ARENA_BITS
 - When RISCV_ENCOMPASSING_ARENA is enabled, this option sets the number of bits each memory address has, effectively making up the size of the address space. For example, 32-bits is a 4GB address space, and 30 is a 1GB address space. 32-bits is most likely the fastest setting. The entire address space is mapped out at construction. Address masking is used to avoid bounds-checking and speculation issues. Experimental feature.
 
-> RISCV_TIMED_VMCALLS
-- Allow execution without instruction counting, instead execution is timed out using timers and signals. Very experimental feature. Works well in a CLI, but should _definitely not_ be used in production.
-
 The fastest configuration is:
 1. Use 32-bit RISC-V for fast instruction dispatch, or 64-bit RISC-V for higher memory bandwidth
 2. Disable C-extension, unless your RISC-V programs use it
 3. Always enable flat read-write arena
 4. Enable experimental + 32-bit encompassing arena
 5. Enable binary translation (or use embedded source files)
-6. Enable timed VM calls
+6. Disable execution timeout (use CPU::simulate_inaccurate)
 7. Enable link-time optimization
 
 Although this is the fastest known configuration, one should use the one that is most convenient.

--- a/emulator/src/main.cpp
+++ b/emulator/src/main.cpp
@@ -144,9 +144,6 @@ static void print_help(const char* name)
 #define STR(x) _STR(x)
 		"-  " STR(RISCV_ENCOMPASSING_ARENA_BITS) "-bit masked address space is enabled (experimental)\n"
 #endif
-#ifdef RISCV_TIMED_VMCALLS
-		"-  Timed VM calls are enabled (experimental)\n"
-#endif
 		"\n",
 		RISCV_VERSION_MAJOR, RISCV_VERSION_MINOR
 	);
@@ -562,13 +559,8 @@ static void run_program(
 			if (cli_args.accurate)
 				machine.simulate(cli_args.fuel);
 			else {
-#ifdef RISCV_TIMED_VMCALLS
-				// Simulation with experimental timeout
-				machine.execute_with_timeout(360.0f, machine.cpu.pc());
-#else
 				// Simulate until it eventually stops (or user interrupts)
 				machine.cpu.simulate_inaccurate(machine.cpu.pc());
-#endif
 			}
 		}
 	} catch (const riscv::MachineException& me) {
@@ -629,11 +621,7 @@ static void run_program(
 		}
 		if (addr != 0) {
 			printf("Calling function %s @ 0x%lX\n", cli_args.call_function.c_str(), long(addr));
-#ifdef RISCV_TIMED_VMCALLS
-			machine.timed_vmcall(addr, 30.0f);
-#else
 			machine.vmcall(addr);
-#endif
 		} else {
 			printf("Error: Function %s not found, not able to call\n", cli_args.call_function.c_str());
 		}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,8 +57,6 @@ if (RISCV_EXPERIMENTAL)
 	else()
 		unset(RISCV_ENCOMPASSING_ARENA_BITS CACHE)
 	endif()
-	# TIMED_VMCALLS enables timed VM calls through timers and signals.
-	option(RISCV_TIMED_VMCALLS       "Enable timed VM calls" OFF)
 else()
 	unset(RISCV_ENCOMPASSING_ARENA CACHE)
 	unset(RISCV_ENCOMPASSING_ARENA_BITS CACHE)
@@ -188,10 +186,6 @@ if (RISCV_EXPERIMENTAL AND RISCV_ENCOMPASSING_ARENA)
 	target_compile_definitions(riscv PUBLIC
 		RISCV_ENCOMPASSING_ARENA_BITS=${RISCV_ENCOMPASSING_ARENA_BITS}
 	)
-endif()
-
-if (RISCV_TIMED_VMCALLS)
-	target_compile_definitions(riscv PUBLIC RISCV_TIMED_VMCALLS=1)
 endif()
 
 if (RISCV_MULTIPROCESS)

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -324,11 +324,6 @@ namespace riscv
 	static constexpr int encompassing_Nbit_arena = 0;
 	static constexpr uint64_t encompassing_arena_mask = 0;
 #endif
-#ifdef RISCV_TIMED_VMCALLS
-	static constexpr bool timed_vm_calls = true;
-#else
-	static constexpr bool timed_vm_calls = false;
-#endif
 #ifdef RISCV_LIBTCC
 	static constexpr bool libtcc_enabled = true;
 #else

--- a/lib/libriscv/machine.cpp
+++ b/lib/libriscv/machine.cpp
@@ -11,11 +11,6 @@
 #ifdef __GNUG__ /* Workaround for GCC bug */
 #include "machine_defaults.cpp"
 #endif
-#ifdef RISCV_TIMED_VMCALLS
-#include <signal.h>
-#include <sys/timerfd.h>
-extern "C" int gettid();
-#endif
 
 namespace riscv
 {
@@ -418,90 +413,6 @@ namespace riscv
 		// if we got here, its an illegal operation!
 		cpu.trigger_exception(ILLEGAL_OPERATION, instr.Itype.funct3);
 	}
-
-#ifdef RISCV_TIMED_VMCALLS
-	struct ksigevent
-	{
-		union sigval sigev_value;
-		int sigev_signo;
-		int sigev_notify;
-		int sigev_tid;
-	};
-
-	extern "C"
-	void timed_vmcall_sighandler(int sig, siginfo_t* si, void* usr)
-	{
-		(void)si; (void)usr;
-		if (sig == SIGUSR2) {
-			throw MachineTimeoutException(MAX_INSTRUCTIONS_REACHED, "Timed out", 0);
-		}
-	}
-
-	template <int W>
-	void Machine<W>::execute_with_timeout(float timeout, address_t pc)
-	{
-		if (this->m_timer_id == nullptr)
-		{
-			// Establish handler for timer signal
-			struct sigaction sa;
-			sa.sa_flags = SA_SIGINFO | SA_NODEFER;
-			sa.sa_sigaction = timed_vmcall_sighandler;
-			sigemptyset(&sa.sa_mask);
-			if (::sigaction(SIGUSR2, &sa, NULL) < 0) {
-				throw MachineException(ILLEGAL_OPERATION, "sigaction failed");
-			}
-
-			// Create the timer
-			struct ksigevent sev {};
-			sev.sigev_signo = SIGUSR2;
-			sev.sigev_notify = SIGEV_THREAD_ID;
-			sev.sigev_tid = ::gettid();
-
-			if (timer_create(CLOCK_MONOTONIC, (struct sigevent *)&sev, &m_timer_id) < 0) {
-				throw MachineException(ILLEGAL_OPERATION, "timer_create failed");
-			}
-		}
-
-		// Start the timer
-		const struct itimerspec its {
-			/* Interrupt every 50ms after timeout. This makes sure
-			that we will eventually exit all blocking calls. If
-			there is a blocking loop that doesn't exit properly,
-			the 50ms recurring interruption should not cause too
-			much wasted CPU-time. */
-			.it_interval = {
-				.tv_sec = 0, .tv_nsec = 50'000'000L
-			},
-			/* The execution timeout. */
-			.it_value = {
-				.tv_sec = (time_t) timeout,
-				.tv_nsec = (long) ((timeout - (time_t) timeout) * 1'000'000'000L)
-			}
-		};
-
-		if (timer_settime(m_timer_id, 0, &its, NULL) < 0) {
-			throw MachineException(SYSTEM_CALL_FAILED, "timer_settime failed");
-		}
-
-		// Execute the VM call
-		try {
-			cpu.simulate_inaccurate(pc);
-		} catch (...) {
-			// Stop the timer
-			disable_timer();
-			throw;
-		}
-		// Stop the timer
-		disable_timer();
-	}
-
-	template <int W>
-	void Machine<W>::disable_timer()
-	{
-		struct itimerspec its {};
-		timer_settime(this->m_timer_id, 0, &its, nullptr);
-	}
-#endif
 
 	INSTANTIATE_32_IF_ENABLED(Machine);
 	INSTANTIATE_64_IF_ENABLED(Machine);

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -418,14 +418,6 @@ namespace riscv
 		Signals<W>& signals();
 		SignalAction<W>& sigaction(int sig) { return signals().get(sig); }
 
-#ifdef RISCV_TIMED_VMCALLS
-		template <typename... Args>
-		address_t timed_vmcall(float timeout, const char* func_name, Args&&... args);
-
-		template <typename... Args>
-		address_t timed_vmcall(float timeout, address_t func_addr, Args&&... args);
-#endif
-
 		// Resets the machine to the initial state. It is, however, not a
 		// reliable way to reset complex machines with all kinds of features
 		// attached to it, and should almost never be used. It is recommended
@@ -467,14 +459,6 @@ namespace riscv
 		std::unique_ptr<Multiprocessing<W>> m_smp = nullptr;
 		std::unique_ptr<Signals<W>> m_signals = nullptr;
 		std::shared_ptr<MachineOptions<W>> m_options = nullptr;
-
-#ifdef RISCV_TIMED_VMCALLS
-	public:
-		void execute_with_timeout(float timeout, address_t pc);
-	private:
-		void disable_timer();
-		void* m_timer_id = nullptr;
-#endif
 
 		static_assert((W == 4 || W == 8 || W == 16), "Must be either 32-bit, 64-bit or 128-bit ISA");
 		static void default_printer(const Machine&, const char*, size_t);

--- a/lib/libriscv/machine_vmcall.hpp
+++ b/lib/libriscv/machine_vmcall.hpp
@@ -53,27 +53,6 @@ inline address_type<W> Machine<W>::vmcall(const char* funcname, Args&&... args)
 	return vmcall<MAXI, Throw>(call_addr, std::forward<Args>(args)...);
 }
 
-#ifdef RISCV_TIMED_VMCALLS
-template <int W>
-template <typename... Args>
-inline address_type<W> Machine<W>::timed_vmcall(float timeout, address_t pc, Args&&... args)
-{
-	this->cpu.reset_stack_pointer();
-	this->setup_call(std::forward<Args>(args)...);
-	this->execute_with_timeout(timeout, pc);
-
-	return cpu.reg(REG_ARG0);
-}
-
-template <int W>
-template <typename... Args>
-inline address_type<W> Machine<W>::timed_vmcall(float timeout, const char* funcname, Args&&... args)
-{
-	address_t call_addr = memory.resolve_address(funcname);
-	return timed_vmcall(timeout, call_addr, std::forward<Args>(args)...);
-}
-#endif
-
 template <int W>
 template <bool Throw, bool StoreRegs, typename... Args> inline
 address_type<W> Machine<W>::preempt(uint64_t max_instr, address_t call_addr, Args&&... args)


### PR DESCRIPTION
This feature would never work correctly when the machine was being timed out during a C++ exception, or any other complex procedure