### PR TITLE
Trim the size of the Machine structure a bit

### DIFF
--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -89,9 +89,6 @@ namespace riscv
 		/// @brief Virtual memory allocated for the main stack at construction.
 		uint32_t stack_size = 1ul << 20; // 1MB default stack
 
-		/// @brief The CPU id to assign to a constructed machine.
-		unsigned cpu_id = 0;
-
 		/// @brief Setting this option will load the binary at construction as if it
 		/// was a RISC-V ELF binary. When disabled, no loading occurs.
 		bool load_program = true;

--- a/lib/libriscv/cpu_inline.hpp
+++ b/lib/libriscv/cpu_inline.hpp
@@ -18,8 +18,8 @@ template <int W> RISCV_ALWAYS_INLINE inline
 const Memory<W>& CPU<W>::memory() const noexcept { return machine().memory; }
 
 template <int W>
-inline CPU<W>::CPU(Machine<W>& machine, unsigned cpu_id)
-	: m_machine { machine }, m_exec(empty_execute_segment().get()), m_cpuid { cpu_id }
+inline CPU<W>::CPU(Machine<W>& machine)
+	: m_machine { machine }, m_exec(empty_execute_segment().get())
 {
 }
 template <int W>

--- a/lib/libriscv/machine.cpp
+++ b/lib/libriscv/machine.cpp
@@ -22,7 +22,7 @@ namespace riscv
 
 	template <int W>
 	inline Machine<W>::Machine(std::string_view binary, const MachineOptions<W>& options)
-		: cpu(*this, options.cpu_id),
+		: cpu(*this),
 		  memory(*this, binary, options),
 		  m_arena(nullptr)
 	{
@@ -30,7 +30,7 @@ namespace riscv
 	}
 	template <int W>
 	inline Machine<W>::Machine(const Machine& other, const MachineOptions<W>& options)
-		: cpu(*this, options.cpu_id, other),
+		: cpu(*this, other),
 		  memory(*this, other, options),
 		  m_arena(nullptr)
 	{

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -515,10 +515,7 @@ namespace riscv
 		this->m_mmap_cache   = master.memory.m_mmap_cache;
 
 		// Reference the same execute segments
-		this->m_exec_segs = master.memory.m_exec_segs;
-		for (size_t i = 0; i < m_exec_segs; i++) {
-			this->m_exec[i] = master.memory.m_exec[i];
-		}
+		this->m_exec = master.memory.m_exec;
 
 		if (options.use_memory_arena) {
 			this->m_arena.data = master.memory.m_arena.data;

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -29,7 +29,6 @@ namespace riscv
 		static constexpr address_t BRK_MAX      = RISCV_BRK_MEMORY_SIZE; // Default BRK size
 		static constexpr address_t DYLINK_BASE  = 0x40000; // Dynamic link base address
 		static constexpr address_t RWREAD_BEGIN = 0x1000; // Default rw-arena rodata start
-		static constexpr size_t    MAX_EXECUTE_SEGS = RISCV_MAX_EXECUTE_SEGS;
 
 		template <typename T>
 		T read(address_t src);
@@ -203,7 +202,7 @@ namespace riscv
 		std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr);
 		const std::shared_ptr<DecodedExecuteSegment<W>>& exec_segment_for(address_t vaddr) const;
 		DecodedExecuteSegment<W>& create_execute_segment(const MachineOptions<W>&, const void* data, address_t addr, size_t len, bool is_initial, bool is_likely_jit = false);
-		size_t cached_execute_segments() const noexcept { return m_exec_segs; }
+		size_t execute_segments_count() const noexcept { return m_exec.size(); }
 		// Evict all execute segments, also disabling the main execute segment
 		void evict_execute_segments();
 		void evict_execute_segment(DecodedExecuteSegment<W>&);
@@ -305,8 +304,7 @@ namespace riscv
 #endif
 
 		// Execute segments
-		std::array<std::shared_ptr<DecodedExecuteSegment<W>>, MAX_EXECUTE_SEGS> m_exec;
-		size_t m_exec_segs = 0;
+		std::vector<std::shared_ptr<DecodedExecuteSegment<W>>> m_exec;
 		std::shared_ptr<DecodedExecuteSegment<W>>& next_execute_segment();
 
 		// Linear arena at start of memory (mmap-backed)

--- a/lib/libriscv/memory_inline.hpp
+++ b/lib/libriscv/memory_inline.hpp
@@ -157,8 +157,7 @@ inline void Memory<W>::set_exit_address(address_t addr)
 template <int W>
 inline std::shared_ptr<DecodedExecuteSegment<W>>& Memory<W>::exec_segment_for(address_t vaddr)
 {
-	for (size_t i = 0; i < m_exec_segs; i++) {
-		auto& segment = m_exec[i];
+	for (auto& segment : m_exec) {
 		if (segment && segment->is_within(vaddr)) return segment;
 	}
 	return CPU<W>::empty_execute_segment();

--- a/lib/libriscv/multiprocessing.cpp
+++ b/lib/libriscv/multiprocessing.cpp
@@ -66,7 +66,7 @@ bool Machine<W>::multiprocess(unsigned num_cpus, uint64_t maxi,
 			try {
 				// NOTE: minimal_fork causes a ton of contention. Avoid!
 				// NOTE: cannot use arena as it can fail to read the origin stack
-				Machine<W> fork { *this, { .cpu_id = id, .use_memory_arena = false } };
+				Machine<W> fork { *this, { .use_memory_arena = false } };
 
 				fork.set_userdata(this->get_userdata<void>());
 				fork.set_printer([] (const auto&, const char*, size_t) {});

--- a/lib/libriscv/page.hpp
+++ b/lib/libriscv/page.hpp
@@ -105,15 +105,15 @@ struct Page
 		if (attr.non_owning) m_page.release();
 	}
 
-	auto& page() noexcept { return *m_page; }
-	const auto& page() const noexcept { return *m_page; }
+	PageData& page() noexcept { return *m_page; }
+	const PageData& page() const noexcept { return *m_page; }
 
 	std::string to_string() const;
 
-	auto* data() noexcept {
+	uint8_t* data() noexcept {
 		return page().buffer8.data();
 	}
-	const auto* data() const noexcept {
+	const uint8_t* data() const noexcept {
 		return page().buffer8.data();
 	}
 	void new_data(PageData* data, bool data_owned);

--- a/lib/libriscv/serialize.cpp
+++ b/lib/libriscv/serialize.cpp
@@ -158,7 +158,7 @@ namespace riscv
 	{
 		// restore CPU registers and counters
 		this->m_regs = state.registers;
-		this->m_cache = {};
+		this->m_exec = CPU::empty_execute_segment().get();
 	}
 	template <int W>
 	void Memory<W>::deserialize_from(const std::vector<uint8_t>& vec,


### PR DESCRIPTION
This commit removes the unused CPU id, slow-path cpu page cache, current_exception (libtcc-only), and places execute segments in a dynamic std::vector.
The slow-path CPU page cache was used by read_next_instruction(), however it can be placed on the stack for precise simulation and passed as an argument.

Making execute segments fully dynamic means we can have as many JIT segments as needed. But there is currently no way to increase this limit outside of changing a global define. Perhaps it should become a MachineOptions setting?

Casual measurements show that this change saves 256 bytes on 32-bit.