### PR TITLE
Fix RSP Server using wrong format spec for 64bit variables on Win

### DIFF
--- a/lib/libriscv/rsp_server.hpp
+++ b/lib/libriscv/rsp_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "machine.hpp"
 #include <cstdarg>
+#include <inttypes.h>
 #include <unistd.h>
 
 /**
@@ -350,7 +351,7 @@ void RSPClient<W>::handle_breakpoint()
 {
 	uint32_t type = 0;
 	uint64_t addr = 0;
-	sscanf(&buffer[1], "%x,%lx", &type, &addr);
+	sscanf(&buffer[1], "%x,%"PRIx64, &type, &addr);
 	if (buffer[0] == 'Z') {
 		this->m_bp.at(m_bp_iterator) = addr;
 		m_bp_iterator = (m_bp_iterator + 1) % m_bp.size();
@@ -401,7 +402,7 @@ void RSPClient<W>::handle_readmem()
 {
 	uint64_t addr = 0;
 	uint32_t len = 0;
-	sscanf(buffer.c_str(), "m%lx,%x", &addr, &len);
+	sscanf(buffer.c_str(), "m%"PRIx64",%x", &addr, &len);
 	if (len >= 500) {
 		send("E01");
 		return;
@@ -428,7 +429,7 @@ void RSPClient<W>::handle_writemem()
 {
 	uint64_t addr = 0;
 	uint32_t len = 0;
-	int ret = sscanf(buffer.c_str(), "X%lx,%x:", &addr, &len);
+	int ret = sscanf(buffer.c_str(), "X%"PRIx64",%x:", &addr, &len);
 	if (ret <= 0) {
 		send("E01");
 		return;
@@ -541,7 +542,7 @@ void RSPClient<W>::handle_writereg()
 {
 	uint64_t value = 0;
 	uint32_t idx = 0;
-	sscanf(buffer.c_str(), "P%x=%lx", &idx, &value);
+	sscanf(buffer.c_str(), "P%x=%"PRIx64, &idx, &value);
 	value = __builtin_bswap64(value);
 
 	if (idx < 32) {


### PR DESCRIPTION
The probably most annoying part of windows/linux crossplatform development.
long int vs long long int..

Example if in `handle_readmem` we get `buffer = "m7fff54c10000,1"`
Old code, when compiled on windows with clang-cl, will read `addr = 0x54c10000` because `%lx` is 32bit.
After this fix, it will use `%lx` on linux (reading 64bit) and `%llx` on windows (reading 64bit).

I have NOT tested this on linux, but the macros I use are standard C so they should be fine?


There are probably more issues like that.
For example for my build to work, I need to comment out `#include <unistd.h>` on windows.
I think it should check and only include it on linux, but you'll know better what it's purpose is.

And also, the `SOCK_NONBLOCK` block at the top doesn't work, it just makes gdb instantly disconnect.
If I comment out L14/15, then I can connect gdb-multiarch from VSCode (which runs gdb via WSL), and debug and step through my RISC code inside VSCode, which is the experience I want to have.
Aaaand also, the SO_REUSEADDR, fails on windows. Commenting that out still works fine though. Do you think its fine to put these behind a #if __linux__ ?
If yes then I'll make another PR for the rest of the changes to make this work on Windows.

Here are all the changes I had to do so far https://github.com/dedmen/libriscv/commits/Fixes/

I just don't know if the way I'm fixing it, is the proper way.
Either no-one else is doing this on Windows? Or I'm doing something wrong.