### PR TITLE
Use RISCV_MACHINE_ALIGNMENT macro to configure alignments

### DIFF
--- a/.github/workflows/zig_unittests.yml
+++ b/.github/workflows/zig_unittests.yml
@@ -31,9 +31,9 @@ jobs:
 
     - name: Get Zig
       run: |
-        wget https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.2546+0ff0bdb4a.tar.xz
-        tar -xf zig-linux-x86_64-0.14.0-dev.2546+0ff0bdb4a.tar.xz
-        mv zig-linux-x86_64-0.14.0-dev.2546+0ff0bdb4a ${{github.workspace}}/zig
+        wget https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.2851+b074fb7dd.tar.xz
+        tar -xf zig-linux-x86_64-0.14.0-dev.2851+b074fb7dd.tar.xz
+        mv zig-linux-x86_64-0.14.0-dev.2851+b074fb7dd ${{github.workspace}}/zig
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -32,6 +32,10 @@
 #define RISCV_FORCE_ALIGN_MEMORY 1
 #endif
 
+#ifndef RISCV_MACHINE_ALIGNMENT
+#define RISCV_MACHINE_ALIGNMENT 32
+#endif
+
 #ifndef RISCV_BRK_MEMORY_SIZE
 #define RISCV_BRK_MEMORY_SIZE  (16ull << 20) // 16MB
 #endif

--- a/lib/libriscv/machine.hpp
+++ b/lib/libriscv/machine.hpp
@@ -30,7 +30,7 @@ namespace riscv
 	/// @brief A RISC-V emulator
 	/// @tparam W The machine architecture
 	template <int W>
-	struct alignas(32) Machine
+	struct alignas(RISCV_MACHINE_ALIGNMENT) Machine
 	{
 		using syscall_t = void(*)(Machine&);
 		using address_t = address_type<W>; // one unsigned memory address

--- a/lib/libriscv/memory.hpp
+++ b/lib/libriscv/memory.hpp
@@ -19,7 +19,7 @@ namespace riscv
 	struct vBuffer { char* ptr; size_t len; };
 
 	template<int W>
-	struct alignas(32) Memory
+	struct alignas(RISCV_MACHINE_ALIGNMENT) Memory
 	{
 		using address_t = address_type<W>;
 		using mmio_cb_t = Page::mmio_cb_t;

--- a/lib/libriscv/registers.hpp
+++ b/lib/libriscv/registers.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "common.hpp"
 #include "types.hpp"
 #include <array>
 #include <memory>
@@ -66,7 +67,7 @@ namespace riscv
 	};
 
 	template <int W>
-	struct alignas(32) Registers
+	struct alignas(RISCV_MACHINE_ALIGNMENT) Registers
 	{
 		using address_t  = address_type<W>;   // one unsigned memory address
 		using register_t = register_type<W>;  // integer register

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -143,7 +143,7 @@ typedef union {
 #define set_dbl(reg, dv)  (reg)->f64 = (dv)
 
 // Thin variant of CPU for higher compilation speed
-__attribute__((aligned(32)))
+__attribute__((aligned(RISCV_MACHINE_ALIGNMENT)))
 typedef struct {
 	addr_t  pc;
 	addr_t  r[32];

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -153,6 +153,7 @@ static std::unordered_map<std::string, std::string> create_defines_for(const Mac
 	std::unordered_map<std::string, std::string> defines;
 	defines.emplace("RISCV_TRANSLATION_DYLIB", std::to_string(W));
 	defines.emplace("RISCV_MAX_SYSCALLS", std::to_string(RISCV_SYSCALLS_MAX));
+	defines.emplace("RISCV_MACHINE_ALIGNMENT", std::to_string(RISCV_MACHINE_ALIGNMENT));
 	if constexpr (W == 16) {
 		defines.emplace("RISCV_ARENA_END", std::to_string(uint64_t(arena_end)));
 		defines.emplace("RISCV_ARENA_ROEND", std::to_string(uint64_t(initial_rodata_end)));


### PR DESCRIPTION
This PR makes it possible to configure the general alignments of all libriscv structures. It will fail to compile if V-extension is enabled and the V-extension alignment is higher than the general alignment.
