### PR TITLE
Fix conversion issue with FCVT.S.W and FCVT.S.WU

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -573,10 +573,10 @@ namespace riscv
 		auto& dst = cpu.registers().getfl(fi.R4type.rd);
 		switch (fi.R4type.funct2) {
 		case 0x0: // to float32
-			if (fi.R4type.rs2 == 0x0)
-				dst.set_float((RVSIGNTYPE(cpu)) rs1);
-			else
-				dst.set_float(rs1);
+			if (fi.R4type.rs2 == 0x0) // FCVT.S.W
+				dst.set_float((int32_t)rs1);
+			else // FCVT.S.WU
+				dst.set_float((uint32_t)rs1);
 			return;
 		case 0x1: // to float64
 			switch (fi.R4type.rs2) {

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1658,11 +1658,28 @@ void Emitter<W>::emit()
 					UNKNOWN_INSTRUCTION();
 				} break;
 			case RV32F__FCVT_SD_W: {
-				const std::string sign((fi.R4type.rs2 == 0x0) ? "(saddr_t)" : "");
 				if (fi.R4type.funct2 == 0x0) {
+					// FCVT.S.W && FCVT.S.WU
+					const std::string sign((fi.R4type.rs2 == 0x0) ? "(int32_t)" : "(uint32_t)");
 					code += "set_fl(&" + dst + ", " + sign + from_reg(fi.R4type.rs1) + ");\n";
 				} else if (fi.R4type.funct2 == 0x1) {
-					code += "set_dbl(&" + dst + ", " + sign + from_reg(fi.R4type.rs1) + ");\n";
+					// FCVT.D.[LWU]
+					switch (fi.R4type.rs2) {
+					case 0x0: // FCVT.D.W
+						code += "set_dbl(&" + dst + ", (int32_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						break;
+					case 0x1: // FCVT.D.WU
+						code += "set_dbl(&" + dst + ", (uint32_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						break;
+					case 0x2: // FCVT.D.L
+						code += "set_dbl(&" + dst + ", (int64_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						break;
+					case 0x3: // FCVT.D.LU
+						code += "set_dbl(&" + dst + ", (uint64_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						break;
+					default:
+						UNKNOWN_INSTRUCTION();
+					}
 				} else {
 					UNKNOWN_INSTRUCTION();
 				}


### PR DESCRIPTION
Also, properly implement FCVT.D.W[U] and FCVT.D.L[U] in binary translator

I really thought I had solved these issues, but clearly not. I had a ghost in my machine with some coordinates not printing properly when converting an int to float, and what do you know: The float was loaded from memory and contained the right value, but somehow the instructions leading to the print failed. The only way it could be so was an emulation bug. Now fixed! Will try to create a test for this later.

So, how could this bug slip away for so long? Well, it's because when you convert an integer to a float, you usually have an integer. Not a 64-bit value, just a 32-bit value that makes sense to convert to a 32-bit float. But, what if you had a 2x packed 32-bit integers as part of a calling convention, that got unpacked and the upper bits never gets zeroed? That's when this bug shows up.
