### PR TITLE
Make JIT default, with live-patching enabled

### DIFF
--- a/.github/workflows/buildconfig.yml
+++ b/.github/workflows/buildconfig.yml
@@ -49,16 +49,16 @@ jobs:
         run: bash ci.sh -DRISCV_THREADED=OFF
 
       - name: No extensions build
-        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=OFF -DRISCV_EXT_F=OFF
+        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=OFF -DRISCV_EXT_V=OFF
 
       - name: A-ext only build
-        run: bash ci.sh -DRISCV_EXT_A=ON -DRISCV_EXT_C=OFF -DRISCV_EXT_F=OFF
+        run: bash ci.sh -DRISCV_EXT_A=ON -DRISCV_EXT_C=OFF -DRISCV_EXT_V=OFF
 
       - name: C-ext only build
-        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=ON -DRISCV_EXT_F=OFF
+        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=ON -DRISCV_EXT_V=OFF
 
-      - name: F-ext only build
-        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=OFF -DRISCV_EXT_F=ON
+      - name: V-ext only build
+        run: bash ci.sh -DRISCV_EXT_A=OFF -DRISCV_EXT_C=OFF -DRISCV_EXT_V=ON
 
       - name: Experimental build
         run: bash ci.sh -DRISCV_EXPERIMENTAL=ON -DRISCV_THREADED=OFF
@@ -69,14 +69,14 @@ jobs:
       - name: Experimental + threaded debug build
         run: bash ci.sh -DRISCV_EXPERIMENTAL=ON -DRISCV_THREADED=ON -DRISCV_DEBUG=ON
 
-      - name: No multiprocessing build
-        run: bash ci.sh -DRISCV_EXPERIMENTAL=ON -DRISCV_MULTIPROCESS=OFF
+      - name: No JIT build
+        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=ON -DRISCV_LIBTCC=OFF
 
-      - name: Multiprocessing debug build
-        run: bash ci.sh -DRISCV_EXPERIMENTAL=ON -DRISCV_MULTIPROCESS=ON -DRISCV_DEBUG=ON
+      - name: No JIT debug build
+        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=ON -DRISCV_LIBTCC=OFF -DRISCV_DEBUG=ON
 
-      - name: Binary translation build
-        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=ON -DRISCV_DEBUG=OFF -DRISCV_EXT_C=OFF
+      - name: Binary translation off build
+        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=OFF -DRISCV_DEBUG=OFF
 
-      - name: Binary translation debug build
-        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=ON -DRISCV_DEBUG=ON -DRISCV_EXT_C=OFF
+      - name: Binary translation off debug build
+        run: bash ci.sh -DRISCV_BINARY_TRANSLATION=OFF -DRISCV_DEBUG=ON

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,7 +24,7 @@ jobs:
         git submodule update --init ${{github.workspace}}/tests/unit/ext/lodepng
 
     - name: Configure
-      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=OFF -DRISCV_FLAT_RW_ARENA=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=OFF -DRISCV_BINARY_TRANSLATION=OFF -DRISCV_FLAT_RW_ARENA=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build the unittests
       run: cmake --build ${{github.workspace}}/build --parallel 4

--- a/.github/workflows/unittests_exp.yml
+++ b/.github/workflows/unittests_exp.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Configure
       env:
         CXX: ${{ matrix.compiler }}
-      run: cmake -B ${{github.workspace}}/build -DRISCV_TAILCALL_DISPATCH=ON -DRISCV_THREADED=OFF -DRISCV_EXPERIMENTAL=ON -DRISCV_FLAT_RW_ARENA=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DRISCV_TAILCALL_DISPATCH=ON -DRISCV_THREADED=OFF -DRISCV_BINARY_TRANSLATION=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build the unittests
       run: cmake --build ${{github.workspace}}/build --parallel 4

--- a/.github/workflows/unittests_threaded.yml
+++ b/.github/workflows/unittests_threaded.yml
@@ -24,7 +24,7 @@ jobs:
         git submodule update --init ${{github.workspace}}/tests/unit/ext/lodepng
 
     - name: Configure
-      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=ON -DRISCV_FLAT_RW_ARENA=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DRISCV_THREADED=ON -DRISCV_BINARY_TRANSLATION=OFF -DRISCV_FLAT_RW_ARENA=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build the unittests
       run: cmake --build ${{github.workspace}}/build --parallel 4

--- a/emulator/src/main.cpp
+++ b/emulator/src/main.cpp
@@ -35,7 +35,7 @@ struct Arguments {
 	bool sandbox = false;
 	bool execute_only = false;
 	bool ignore_text = false;
-	bool background = false; // Run binary translation in background thread
+	bool background = true; // Run binary translation in background thread
 	bool proxy_mode = false;  // Proxy mode for system calls
 	uint64_t fuel = 30'000'000'000ULL; // Default: Timeout after ~30bn instructions
 	uint64_t max_memory = 0;
@@ -67,6 +67,7 @@ static const struct option long_options[] = {
 	{"no-translate-regcache", no_argument, 0, 1000},
 	{"jump-hints", required_argument, 0, 'J'},
 	{"background", no_argument, 0, 'B'},
+	{"no-background", no_argument, 0, 1001},
 	{"mingw", no_argument, 0, 'M'},
 	{"output", required_argument, 0, 'o'},
 	{"from-start", no_argument, 0, 'F'},
@@ -100,7 +101,8 @@ static void print_help(const char* name)
 		"  -R, --translate-regcache Enable register caching in binary translator\n"
 		"      --no-translate-regcache Disable register caching in binary translator\n"
 		"  -J, --jump-hints file  Load jump location hints from file, unless empty then record instead\n"
-		"  -B  --background   Run binary translation in background thread\n"
+		"  -B  --background   Run binary translation in background w/live-patching\n"
+		"      --no-background Disable background binary translation\n"
 		"  -M, --mingw        Cross-compile for Windows (MinGW)\n"
 		"  -o, --output file  Output embeddable binary translated code (C99)\n"
 		"  -F, --from-start   Start debugger from the beginning (_start)\n"
@@ -184,6 +186,7 @@ static int parse_arguments(int argc, const char** argv, Arguments& args)
 			case 'X': args.execute_only = true; break;
 			case 'I': args.ignore_text = true; break;
 			case 1000: args.translate_regcache = false; break;
+			case 1001: args.background = false; break;
 			case 'm': // --memory
 				if (optarg) {
 					char* endptr;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,7 +23,7 @@ option(RISCV_EXPERIMENTAL  "Enable experimental features" OFF)
 option(RISCV_MEMORY_TRAPS  "Enable memory page traps" ON)
 # BINARY_TRANSLATION will make libriscv generate portable C-code,
 # and invoke a system compiler to execute a program much faster.
-option(RISCV_BINARY_TRANSLATION  "Enable exp. binary translation" OFF)
+option(RISCV_BINARY_TRANSLATION  "Enable exp. binary translation" ON)
 # FLAT_RW_ARENA simplifies the program arena, making the heap area always read-write.
 # Memory before the heap and outside of the arena behaves like before.
 option(RISCV_FLAT_RW_ARENA       "Enable performant flat read-write arena" ON)
@@ -65,7 +65,7 @@ else()
 endif()
 if (RISCV_BINARY_TRANSLATION)
 	# LIBTCC will embed the TCC compiler library, using it for binary translation.
-	option(RISCV_LIBTCC              "Enable binary translation with libtcc" OFF)
+	option(RISCV_LIBTCC              "Enable binary translation with libtcc" ON)
 endif()
 
 # Version information from git tags

--- a/lib/libriscv/common.hpp
+++ b/lib/libriscv/common.hpp
@@ -203,6 +203,14 @@ namespace riscv
 		/// @details This will record slowpaths to the MachineOptions jump hints vector.
 		/// From there the CLI can save the jump hints to a file after the program has run.
 		bool record_slowpaths_to_jump_hints = false;
+		/// @brief Enable live-patching a running instruction stream after background compilation.
+		/// @details This will allow the binary translator to patch the running instruction stream
+		/// with the newly compiled code, which allows it to switch to the newly compiled code
+		/// without stopping the program.
+		/// @warning This is an experimental feature and may not work correctly in all cases.
+		/// @note Disabling this option will not disable background compilation, it will just
+		/// not hot-reload the execution with the new binary translation when the emulator is running.
+		bool translate_live_patching = true;
 		/// @brief Prefix for the translation output file.
 		std::string translation_prefix = "/tmp/rvbintr-";
 		/// @brief Suffix for the translation output file. Eg. .dll or .so

--- a/lib/libriscv/memory.cpp
+++ b/lib/libriscv/memory.cpp
@@ -12,7 +12,7 @@ __cxa_demangle(const char *name, char *buf, size_t *n, int *status);
 
 namespace riscv
 {
-	static constexpr uint64_t UNBOUNDED_ARENA_SIZE = (1ULL << encompassing_Nbit_arena) + Page::size();
+	[[maybe_unused]] static constexpr uint64_t UNBOUNDED_ARENA_SIZE = (1ULL << encompassing_Nbit_arena) + Page::size();
 
 	template <int W>
 	Memory<W>::Memory(Machine<W>& mach, std::string_view bin,

--- a/lib/libriscv/tailcall_dispatch.cpp
+++ b/lib/libriscv/tailcall_dispatch.cpp
@@ -165,6 +165,17 @@ namespace riscv
 		auto new_values = 
 			exec->mapping_at(instr.whole)(CPU(), counter.value()-1, counter.max(), pc);
 		counter.set_counters(new_values.counter, new_values.max_counter);
+		if (new_values.max_counter == 0) {
+#ifdef RISCV_LIBTCC
+			// We need to check if we have a current exception
+			if (UNLIKELY(CPU().has_current_exception())) {
+				const auto except = CPU().current_exception();
+				CPU().clear_current_exception();
+				std::rethrow_exception(except);
+			}
+#endif
+			return RETURN_VALUES();
+		}
 		pc = REGISTERS().pc;
 		OVERFLOW_CHECK();
 		UNCHECKED_JUMP();


### PR DESCRIPTION
The JIT has been tested on:
- Windows
- Linux
- Android
- macOS

The first commit probably stopped testing the base interpreter, so that has to be enabled again, but it will be interesting to see if the initial commit can pass all the tests regardless!
