### PR TITLE
rv64: use the six-bit immediate for SLLI.UW

### DIFF
--- a/lib/libriscv/rvi_instr.cpp
+++ b/lib/libriscv/rvi_instr.cpp
@@ -1016,7 +1016,7 @@ static inline uint64_t MUL128(
 		auto& dst = cpu.reg(instr.Itype.rd);
 		const uint32_t src = cpu.reg(instr.Itype.rs1);
 		// SLLI.UW: Shift-left Unsigned Word (Immediate)
-		dst = RVREGTYPE(cpu)(src) << instr.Itype.shift_imm();
+		dst = RVREGTYPE(cpu)(src) << instr.Itype.shift64_imm();
 	}, DECODED_INSTR(OP_IMM32_ADDIW).printer);
 
 	INSTRUCTION(OP_IMM32,

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1610,7 +1610,7 @@ void Emitter<W>::emit()
 					add_code(dst + " = " + SIGNEXTW + " (" + src + " << " + from_imm(instr.Itype.shift_imm()) + ");");
 				} else if (instr.Itype.high_bits() == 0x080) {
 					// SLLI.UW
-					add_code(dst + " = ((addr_t)" + src + " << " + from_imm(instr.Itype.shift_imm()) + ");");
+					add_code(dst + " = ((addr_t)" + src + " << " + from_imm(instr.Itype.shift64_imm()) + ");");
 				} else {
 					switch (instr.Itype.imm) {
 					case 0b011000000000: // CLZ.W


### PR DESCRIPTION
Fixes #322

`SLLI.UW` uses a six-bit shift immediate on RV64. The interpreter and binary
translator currently read only five bits, so an immediate of 32 is treated as
zero.

## Change

Use `shift64_imm()` for `SLLI.UW` in `lib/libriscv/rvi_instr.cpp` and
`lib/libriscv/tr_emit.cpp`.
