### PR TITLE
rv64: include the top multiplier bit in CLMULR

### DIFF
--- a/lib/libriscv/rvi_instr.cpp
+++ b/lib/libriscv/rvi_instr.cpp
@@ -720,7 +720,7 @@ static inline uint64_t MUL128(
 			} return;
 		case 0x52: { // CLMULR
 			auto result = 0;
-			for (unsigned i = 0; i < RVXLEN(cpu)-1; i++)
+			for (unsigned i = 0; i < RVXLEN(cpu); i++)
 				if ((src2 >> i) & 1)
 					result ^= (src1 >> (RVXLEN(cpu) - i - 1));
 			dst = result;

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1423,7 +1423,7 @@ void Emitter<W>::emit()
 			case 0x52: // CLMULR
 				add_code(
 					"{ addr_t result = 0;",
-					"for (unsigned i = 0; i < XLEN-1; i++)",
+					"for (unsigned i = 0; i < XLEN; i++)",
 					"  if ((" + from_reg(instr.Rtype.rs2) + " >> i) & 1)",
 					"    result ^= (" + from_reg(instr.Rtype.rs1) + " >> (XLEN - i - 1));",
 					to_reg(instr.Rtype.rd) + " = result; }");


### PR DESCRIPTION
Fixes #323

`CLMULR` currently excludes multiplier bit 63 on RV64. A value with only that
bit set in `rs2` therefore loses its only contribution to the result.

## Change

Include the final loop iteration in the `CLMULR` implementations in
`lib/libriscv/rvi_instr.cpp` and `lib/libriscv/tr_emit.cpp`.
