### PR TITLE
binary translation: sign-extend SLTIU immediates to XLEN

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1230,7 +1230,7 @@ void Emitter<W>::emit()
 				break;
 			case 0x3: // SLTU:
 				add_code(
-					dst + " = (" + src + " < (unsigned) " + from_imm(instr.Itype.signed_imm()) + ") ? 1 : 0;");
+					dst + " = (" + src + " < (addr_t) " + from_imm(instr.Itype.signed_imm()) + ") ? 1 : 0;");
 				break;
 			case 0x4: // XORI:
 				emit_op(" ^ ", " ^= ", instr.Itype.rd, instr.Itype.rs1, from_imm(instr.Itype.signed_imm()));


### PR DESCRIPTION

Fixes #328

## Minimal change

In the `SLTIU` lowering in `lib/libriscv/tr_emit.cpp`, replace the host-dependent `(unsigned)` cast of the signed immediate with `(addr_t)`. `addr_t` is the generated code's XLEN unsigned type, so the existing signed immediate is converted to the correct RV64 bit pattern before comparison.

No decoder or interpreter change is required.

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `SLTIU` immediate conversion only.