### PR TITLE
binary translation: fix signed high-half correction for RV64 MULH

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1349,7 +1349,10 @@ void Emitter<W>::emit()
 				add_code(
 					(W == 4) ?
 					to_reg(instr.Rtype.rd) + " = (uint64_t)((int64_t)(saddr_t)" + from_reg(instr.Rtype.rs1) + " * (int64_t)(saddr_t)" + from_reg(instr.Rtype.rs2) + ") >> 32u;" :
-					"MUL128(&" + to_reg(instr.Rtype.rd) + ", " + from_reg(instr.Rtype.rs1) + ", " + from_reg(instr.Rtype.rs2) + ");"
+					"{ addr_t lhs = " + from_reg(instr.Rtype.rs1) + "; addr_t rhs = " + from_reg(instr.Rtype.rs2) + ";",
+					"MUL128(&" + to_reg(instr.Rtype.rd) + ", lhs, rhs);",
+					"if ((saddr_t)lhs < 0) " + to_reg(instr.Rtype.rd) + " -= rhs;",
+					"if ((saddr_t)rhs < 0) " + to_reg(instr.Rtype.rd) + " -= lhs; }"
 				);
 				break;
 			case 0x12: // MULHSU (signed x unsigned)


### PR DESCRIPTION

Fixes #329

## Minimal change

Keep `MUL128` as the unsigned primitive, but in the RV64 `MULH` lowering:

1. Save both operands as `addr_t` values.
2. Obtain their unsigned high product with `MUL128`.
3. Subtract `rs2` when signed `rs1` is negative.
4. Subtract `rs1` when signed `rs2` is negative.

This is the standard unsigned-to-signed high-product correction. The RV32 lowering remains unchanged.

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `MULH` lowering only.