### PR TITLE
binary translation: fix signed correction for RV64 MULHSU

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1356,7 +1356,9 @@ void Emitter<W>::emit()
 				add_code(
 					(W == 4) ?
 					to_reg(instr.Rtype.rd) + " = (uint64_t)((int64_t)(saddr_t)" + from_reg(instr.Rtype.rs1) + " * (uint64_t)" + from_reg(instr.Rtype.rs2) + ") >> 32u;" :
-					"MUL128(&" + to_reg(instr.Rtype.rd) + ", " + from_reg(instr.Rtype.rs1) + ", " + from_reg(instr.Rtype.rs2) + ");"
+					"{ addr_t lhs = " + from_reg(instr.Rtype.rs1) + "; addr_t rhs = " + from_reg(instr.Rtype.rs2) + ";",
+					"MUL128(&" + to_reg(instr.Rtype.rd) + ", lhs, rhs);",
+					"if ((saddr_t)lhs < 0) " + to_reg(instr.Rtype.rd) + " -= rhs; }"
 				);
 				break;
 			case 0x13: // MULHU (unsigned x unsigned)


### PR DESCRIPTION

Fixes #330

## Minimal change

In the RV64 `MULHSU` lowering in `lib/libriscv/tr_emit.cpp`, retain the unsigned `MUL128` call, save both operands as `addr_t`, and subtract `rs2` from the high half when `(saddr_t)rs1 < 0`. The second operand is unsigned, so no second correction is valid. Leave the RV32 path unchanged.

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `MULHSU` signed correction only.