### PR TITLE
binary translation: perform ROLW in 32 bits

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1718,7 +1718,8 @@ void Emitter<W>::emit()
 			case 0x301: // ROLW: Rotate left 32-bit
 				add_code(
 				"{const unsigned shift = " + from_reg(instr.Rtype.rs2) + " & 31;\n",
-					dst + " = (int32_t)(" + from_reg(instr.Rtype.rs1) + " << shift) | (" + from_reg(instr.Rtype.rs1) + " >> (32 - shift)); }"
+					"const uint32_t word = (uint32_t)" + from_reg(instr.Rtype.rs1) + ";\n",
+					dst + " = (int32_t)((word << shift) | (word >> ((32 - shift) & 31))); }"
 				);
 				break;
 			case 0x305: // RORW: Rotate right (32-bit)


### PR DESCRIPTION

Fixes #331

## Minimal change

Modify only the `ROLW` lowering in `lib/libriscv/tr_emit.cpp`:

1. Copy `rs1` to `uint32_t`.
2. Rotate that word using `rs2 & 31`.
3. Mask the complementary count to avoid a shift by 32.
4. Cast the completed word to `int32_t` for RV64 writeback.

```cpp
const uint32_t word = (uint32_t)rs1;
const unsigned shift = rs2 & 31;
dst = (int32_t)((word << shift) | (word >> ((32 - shift) & 31)));
```

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `ROLW` lowering only.