### PR TITLE
binary translation: implement RV64 divide-by-zero writeback

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1381,11 +1381,13 @@ void Emitter<W>::emit()
 						"		" + to_reg(instr.Rtype.rd) + " = (int32_t)" + from_reg(instr.Rtype.rs1) + " / (int32_t)" + from_reg(instr.Rtype.rs2) + ";",
 						"}");
 				}
+				add_code("if (UNLIKELY(" + from_reg(instr.Rtype.rs2) + " == 0)) " + to_reg(instr.Rtype.rd) + " = (addr_t)-1;");
 				break;
 			case 0x15: // DIVU
 				add_code(
 					"if (LIKELY(" + from_reg(instr.Rtype.rs2) + " != 0))",
-					to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + " / " + from_reg(instr.Rtype.rs2) + ";"
+					to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + " / " + from_reg(instr.Rtype.rs2) + ";",
+					"else " + to_reg(instr.Rtype.rd) + " = (addr_t)-1;"
 				);
 				break;
 			case 0x16: // REM
@@ -1402,11 +1404,13 @@ void Emitter<W>::emit()
 					"		" + to_reg(instr.Rtype.rd) + " = (int32_t)" + from_reg(instr.Rtype.rs1) + " % (int32_t)" + from_reg(instr.Rtype.rs2) + ";",
 					"}");
 				}
+				add_code("if (UNLIKELY(" + from_reg(instr.Rtype.rs2) + " == 0)) " + to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + ";");
 				break;
 			case 0x17: // REMU
 				add_code(
 				"if (LIKELY(" + from_reg(instr.Rtype.rs2) + " != 0))",
-					to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + " % " + from_reg(instr.Rtype.rs2) + ";"
+					to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + " % " + from_reg(instr.Rtype.rs2) + ";",
+					"else " + to_reg(instr.Rtype.rd) + " = " + from_reg(instr.Rtype.rs1) + ";"
 				);
 				break;
 			case 0x44: // ZEXT.H: Zero-extend 16-bit


### PR DESCRIPTION

Fixes #332

## Minimal change

Modify only the generated RV64 paths in `lib/libriscv/tr_emit.cpp`:

- Add an `else` assignment of `(addr_t)-1` for `DIV` and `DIVU` when `rs2 == 0`.
- Add an `else` assignment of `rs1` for `REM` and `REMU` when `rs2 == 0`.

Do not change the existing nonzero-divisor arithmetic or the signed-overflow handling. The patch restores the architectural zero-divisor fallback that the current generated guards omit.

## Source scope

`lib/libriscv/tr_emit.cpp` - the translated RV64 `DIV`, `DIVU`, `REM`, and `REMU` zero-divisor writebacks only.