### PR TITLE
binary translation: perform RORIW in 32 bits before sign extension

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1635,8 +1635,9 @@ void Emitter<W>::emit()
 						dst + " = (int32_t)" + src + " >> " + from_imm(instr.Itype.shift_imm()) + ";");
 				} else if (instr.Itype.high_bits() == 0x600) { // RORIW
 					add_code(
-					"{const unsigned shift = " + from_imm(instr.Itype.imm) + " & 31;\n",
-						dst + " = (int32_t)(" + src + " >> shift) | (" + src + " << (32 - shift)); }"
+						"{const unsigned shift = " + from_imm(instr.Itype.imm) + " & 31;\n",
+						"const uint32_t word = " + src + ";\n",
+						dst + " = (int32_t)((word >> shift) | (word << ((32 - shift) & 31))); }"
 					);
 				} else {
 					UNKNOWN_INSTRUCTION();


### PR DESCRIPTION

Fixes #338

## Problem

Translated RV64 `RORIW` currently lets an XLEN-wide operand participate in the generated rotation expression. Consequently, a result whose bit 31 is set is not reliably sign-extended as required for RV64 word instructions.

## Minimal fix

Change only the `RORIW` lowering in `lib/libriscv/tr_emit.cpp`:

1. Convert the source to `uint32_t` before either shift.
2. Rotate that 32-bit value.
3. Convert the completed 32-bit result to `int32_t` before assigning it to the XLEN destination.
4. Mask the complementary shift count (or use an existing rotate helper) so `shamt == 0` never emits a shift by 32.

Illustrative generated-code shape:

```cpp
const uint32_t word = (uint32_t)src;
const unsigned shift = imm & 31;
dst = (int32_t)((word >> shift) | (word << ((32 - shift) & 31)));
```

## Relationship to this report

This PR addresses only `RORIW` word-width handling. It does not fold in other
word-rotation or word-shift changes.

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `RORIW` lowering only.