### PR TITLE
binary translation: fix RORW word width and sign extension

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1724,7 +1724,8 @@ void Emitter<W>::emit()
 			case 0x305: // RORW: Rotate right (32-bit)
 				add_code(
 				"{const unsigned shift = " + from_reg(instr.Rtype.rs2) + " & 31;\n",
-					dst + " = (int32_t)(" + from_reg(instr.Rtype.rs1) + " >> shift) | (" + from_reg(instr.Rtype.rs1) + " << (32 - shift)); }"
+					"const uint32_t word = (uint32_t)" + from_reg(instr.Rtype.rs1) + ";\n",
+					dst + " = (int32_t)((word >> shift) | (word << ((32 - shift) & 31))); }"
 				);
 				break;
 			default:


### PR DESCRIPTION

Fixes #339

## Minimal change

Modify only the `RORW` branch in `lib/libriscv/tr_emit.cpp`:

1. Copy `rs1` to `uint32_t` before the rotation.
2. Rotate that word using the register count masked to five bits.
3. Mask the complementary count to avoid a shift by 32.
4. Cast the completed word result to `int32_t` for RV64 writeback.

Illustrative generated code:

```cpp
const uint32_t word = (uint32_t)rs1;
const unsigned shift = rs2 & 31;
dst = (int32_t)((word >> shift) | (word << ((32 - shift) & 31)));
```

## Source scope

`lib/libriscv/tr_emit.cpp` - the RV64 `RORW` lowering only.