### PR TITLE
binary translation: implement DIVUW and REMUW zero-divisor writeback

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1688,6 +1688,7 @@ void Emitter<W>::emit()
 				add_code(
 				"if (LIKELY(" + src2 + " != 0))",
 				dst + " = " + SIGNEXTW + " (" + src1 + " / " + src2 + ");");
+				add_code("if (UNLIKELY(" + src2 + " == 0)) " + dst + " = (addr_t)(int32_t)-1;");
 				break;
 			case 0x16: // REMW
 				add_code(
@@ -1699,6 +1700,7 @@ void Emitter<W>::emit()
 				add_code(
 				"if (LIKELY(" + src2 + " != 0))",
 				dst + " = " + SIGNEXTW + " (" + src1 + " % " + src2 + ");");
+				add_code("if (UNLIKELY(" + src2 + " == 0)) " + dst + " = " + SIGNEXTW + " (" + src1 + ");");
 				break;
 			case 0x40: // ADD.UW
 				add_code(dst + " = " + from_reg(instr.Rtype.rs2) + " + " + src1 + ";");


### PR DESCRIPTION

Fixes #340

## Minimal change

In `lib/libriscv/tr_emit.cpp`, add only the missing zero-divisor writebacks:

- `DIVUW`: assign `(int32_t)-1` when `rs2 == 0`.
- `REMUW`: assign `(int32_t)rs1` when `rs2 == 0`.

The explicit `int32_t` conversion is necessary: both word instructions sign-extend their 32-bit result to RV64 XLEN.

## Source scope

`lib/libriscv/tr_emit.cpp` - the translated RV64 `DIVUW` and `REMUW` zero-divisor writebacks only.