### PR TITLE
binary translation: implement DIVW and REMW zero-divisor writeback

### DIFF
--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1683,6 +1683,7 @@ void Emitter<W>::emit()
 				"if (LIKELY(" + src2 + " != 0))",
 				"if (LIKELY(!((int32_t)" + src1 + " == -2147483648 && (int32_t)" + src2 + " == -1)))",
 				dst + " = " + SIGNEXTW + " ((int32_t)" + src1 + " / (int32_t)" + src2 + ");");
+				add_code("if (UNLIKELY(" + src2 + " == 0)) " + dst + " = (addr_t)(int32_t)-1;");
 				break;
 			case 0x15: // DIVUW
 				add_code(
@@ -1694,6 +1695,7 @@ void Emitter<W>::emit()
 				"if (LIKELY(" + src2 + " != 0))",
 				"if (LIKELY(!((int32_t)" + src1 + " == -2147483648 && (int32_t)" + src2 + " == -1)))",
 				dst + " = " + SIGNEXTW + " ((int32_t)" + src1 + " % (int32_t)" + src2 + ");");
+				add_code("if (UNLIKELY(" + src2 + " == 0)) " + dst + " = " + SIGNEXTW + " (" + src1 + ");");
 				break;
 			case 0x17: // REMUW
 				add_code(


### PR DESCRIPTION

Fixes #341

## Minimal change

In `lib/libriscv/tr_emit.cpp`, add the missing zero-divisor writebacks after the existing nonzero-divisor guards:

- `DIVW`: assign `(int32_t)-1`.
- `REMW`: assign `(int32_t)rs1`.

The existing signed-overflow handling and nonzero arithmetic remain unchanged.

## Source scope

`lib/libriscv/tr_emit.cpp` - the translated RV64 `DIVW` and `REMW` zero-divisor writebacks only.