### PR TITLE
Handle quiet NaNs in FSQRT

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -390,12 +390,26 @@ namespace riscv
 		auto& dst = cpu.registers().getfl(fi.R4type.rd);
 		switch (fi.R4type.funct2) {
 		case 0x0: // FSQRT.S
-			dst.set_float(sqrtf(rs1.f32[0]));
-			fsflags(cpu, std::sqrt((double)(rs1.f32[0])), dst.f32[0]);
+			if (std::isnan(rs1.f32[0])) {
+				dst.load_u32(CANONICAL_NAN_F32);
+				if constexpr (fcsr_emulation) {
+					if ((rs1.i32[0] & 0x7fc00000u) == 0x7f800000u) cpu.registers().fcsr().fflags |= 16;
+				}
+			} else {
+				dst.set_float(sqrtf(rs1.f32[0]));
+				fsflags(cpu, std::sqrt((double)(rs1.f32[0])), dst.f32[0]);
+			}
 			break;
 		case 0x1: // FSQRT.D
-			dst.f64 = sqrt(rs1.f64);
-			fsflags(cpu, std::sqrt((long double)(rs1.f64)), dst.f64);
+			if (std::isnan(rs1.f64)) {
+				dst.load_u64(CANONICAL_NAN_F64);
+				if constexpr (fcsr_emulation) {
+					if (is_signaling_nan(rs1.f64)) cpu.registers().fcsr().fflags |= 16;
+				}
+			} else {
+				dst.f64 = sqrt(rs1.f64);
+				fsflags(cpu, std::sqrt((long double)(rs1.f64)), dst.f64);
+			}
 			break;
 		default:
 			cpu.trigger_exception(ILLEGAL_OPERATION);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1992,10 +1992,10 @@ void Emitter<W>::emit()
 				break;
 			case RV32F__FSQRT:
 				if (fi.R4type.funct2 == 0x0) { // fp32
-					code += "set_fl(&" + dst + ", api.sqrtf32(" + rs1 + ".f32[0]));\n";
+					code += "if ((" + rs1 + ".i32[0] & 0x7f800000u) == 0x7f800000u && (" + rs1 + ".i32[0] & 0x007fffffu)) { " + dst + ".i32[0] = 0x7fc00000u; " + dst + ".i32[1] = ~0u; if (!(" + rs1 + ".i32[0] & 0x00400000u)) cpu->fcsr |= 0x10; } else set_fl(&" + dst + ", api.sqrtf32(" + rs1 + ".f32[0]));\n";
 					this->penalty(10); // sqrtf is a slow operation
 				} else { // fp64
-					code += "set_dbl(&" + dst + ", api.sqrtf64(" + rs1 + ".f64));\n";
+					code += "if ((" + rs1 + ".i64 & 0x7ff0000000000000ull) == 0x7ff0000000000000ull && (" + rs1 + ".i64 & 0x000fffffffffffffull)) { " + dst + ".i64 = 0x7ff8000000000000ull; if (!(" + rs1 + ".i64 & 0x0008000000000000ull)) cpu->fcsr |= 0x10; } else set_dbl(&" + dst + ", api.sqrtf64(" + rs1 + ".f64));\n";
 					this->penalty(15); // sqrtd is a slow operation
 				}
 				break;


### PR DESCRIPTION
Fixes #348

Handle NaN inputs before the host square-root helper in the interpreter and binary translator.  The change writes the canonical quiet NaN and raises `NV` only for a signaling input.

Files changed: `lib/libriscv/rvf_instr.cpp`, `lib/libriscv/tr_emit.cpp`.