### PR TITLE
Return the finite operand for one-NaN FMIN.S and FMAX.S

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -460,6 +460,10 @@ namespace riscv
 			if constexpr (fcsr_emulation) {
 				if (std::isnan(rs1.f32[0]) && std::isnan(rs2.f32[0]))
 					dst.load_u32(CANONICAL_NAN_F32);
+				else if (std::isnan(rs1.f32[0]))
+					dst.load_u32(rs2.i32[0]);
+				else if (std::isnan(rs2.f32[0]))
+					dst.load_u32(rs1.i32[0]);
 				else
 					dst.load_u32(fmin32(rs1.i32[0], rs2.i32[0]));
 			} else {
@@ -470,6 +474,10 @@ namespace riscv
 			if constexpr (fcsr_emulation) {
 				if (std::isnan(rs1.f32[0]) && std::isnan(rs2.f32[0]))
 					dst.load_u32(CANONICAL_NAN_F32);
+				else if (std::isnan(rs1.f32[0]))
+					dst.load_u32(rs2.i32[0]);
+				else if (std::isnan(rs2.f32[0]))
+					dst.load_u32(rs1.i32[0]);
 				else
 					dst.load_u32(fmax32(rs1.i32[0], rs2.i32[0]));
 			} else {

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1955,10 +1955,10 @@ void Emitter<W>::emit()
 				// a sign that disagrees with the spec).
 				switch (fi.R4type.funct3 | (fi.R4type.funct2 << 4)) {
 				case 0x0: // FMIN.S
-					code += "set_fl(&" + dst + ", api.fmin32_rv(" + rs1 + ".f32[0], " + rs2 + ".f32[0]));\n";
+					code += "if ((((" + rs1 + ".i32[0] & 0x7fc00000u) == 0x7f800000u && (" + rs1 + ".i32[0] & 0x003fffffu)) || ((" + rs2 + ".i32[0] & 0x7fc00000u) == 0x7f800000u && (" + rs2 + ".i32[0] & 0x003fffffu))) cpu->fcsr |= 0x10; set_fl(&" + dst + ", api.fmin32_rv(" + rs1 + ".f32[0], " + rs2 + ".f32[0]));\n";
 					break;
 				case 0x1: // FMAX.S
-					code += "set_fl(&" + dst + ", api.fmax32_rv(" + rs1 + ".f32[0], " + rs2 + ".f32[0]));\n";
+					code += "if ((((" + rs1 + ".i32[0] & 0x7fc00000u) == 0x7f800000u && (" + rs1 + ".i32[0] & 0x003fffffu)) || ((" + rs2 + ".i32[0] & 0x7fc00000u) == 0x7f800000u && (" + rs2 + ".i32[0] & 0x003fffffu))) cpu->fcsr |= 0x10; set_fl(&" + dst + ", api.fmax32_rv(" + rs1 + ".f32[0], " + rs2 + ".f32[0]));\n";
 					break;
 				case 0x10: // FMIN.D
 					code += "set_dbl(&" + dst + ", api.fmin64_rv(" + rs1 + ".f64, " + rs2 + ".f64));\n";

--- a/lib/libriscv/tr_translate.cpp
+++ b/lib/libriscv/tr_translate.cpp
@@ -1541,6 +1541,14 @@ CallbackTable<W> create_bintr_callback_table(DecodedExecuteSegment<W>&)
 		// FMIN/FMAX with RISC-V -0.0 < +0.0 convention. std::fmin/fmax
 		// leave the ±0 case implementation-defined.
 		.fmin32_rv = [] (float a, float b) -> float {
+			if (std::isnan(a) && std::isnan(b)) {
+				uint32_t bits = 0x7fc00000u;
+				float result;
+				__builtin_memcpy(&result, &bits, sizeof(result));
+				return result;
+			}
+			if (std::isnan(a)) return b;
+			if (std::isnan(b)) return a;
 			if (a == 0.0f && b == 0.0f) {
 				uint32_t ab, bb;
 				__builtin_memcpy(&ab, &a, 4); __builtin_memcpy(&bb, &b, 4);
@@ -1550,6 +1558,8 @@ CallbackTable<W> create_bintr_callback_table(DecodedExecuteSegment<W>&)
 			return std::fmin(a, b);
 		},
 		.fmax32_rv = [] (float a, float b) -> float {
+			if (std::isnan(a)) return b;
+			if (std::isnan(b)) return a;
 			if (a == 0.0f && b == 0.0f) {
 				uint32_t ab, bb;
 				__builtin_memcpy(&ab, &a, 4); __builtin_memcpy(&bb, &b, 4);


### PR DESCRIPTION
Fixes #350

Handle one-NaN inputs explicitly in the interpreter and translated callbacks so FMIN.S and FMAX.S return the finite operand. Generated translated code raises `NV` only for a signaling NaN. Its raw-bit predicate requires an all-ones exponent, a clear quiet bit, and a nonzero payload, so infinities and quiet NaNs do not raise `NV`.

Files changed: `lib/libriscv/rvf_instr.cpp`, `lib/libriscv/tr_emit.cpp`, `lib/libriscv/tr_translate.cpp`.