### PR TITLE
Distinguish quiet and signaling single-precision NaNs

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -32,7 +32,7 @@ namespace riscv
 	template <typename T>
 	static bool is_signaling_nan(T t) {
 		if constexpr (sizeof(T) == 4)
-			return (*(uint32_t*)&t & 0x7fa00000) == 0x7f800000;
+			return (*(uint32_t*)&t & 0x7fc00000) == 0x7f800000;
 		else
 			return (*(uint64_t*)&t & 0x7ffe000000000000) == 0x7ff0000000000000;
 	}


### PR DESCRIPTION
Fixes #351

Use the quiet-bit-inclusive mask when classifying a single-precision signaling NaN, so quiet NaNs no longer raise `NV`.

Files changed: `lib/libriscv/rvf_instr.cpp`.