### PR TITLE
Classify FMIN.D and FMAX.D NaNs at double precision

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -491,7 +491,10 @@ namespace riscv
 			cpu.trigger_exception(ILLEGAL_OPERATION);
 		}
 		if constexpr (fcsr_emulation) {
-			if (is_signaling_nan(rs1.f32[0]) || is_signaling_nan(rs2.f32[0]))
+			const bool snan = fi.R4type.funct2 == 0x0
+				? (is_signaling_nan(rs1.f32[0]) || is_signaling_nan(rs2.f32[0]))
+				: (is_signaling_nan(rs1.f64) || is_signaling_nan(rs2.f64));
+			if (snan)
 				cpu.registers().fcsr().fflags = 16;
 			else
 				cpu.registers().fcsr().fflags = 0;


### PR DESCRIPTION
Fixes #358

Select the `.S` or `.D` operand representation before checking whether either operand is a signaling NaN in the FCSR update for `FMIN` and `FMAX`.

Changed file: `lib/libriscv/rvf_instr.cpp`.