### PR TITLE
Use 64-bit sources for FCVT.S.L and FCVT.S.LU

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -651,11 +651,13 @@ namespace riscv
 		auto& dst = cpu.registers().getfl(fi.R4type.rd);
 		switch (fi.R4type.funct2) {
 		case 0x0: // to float32
-			if (fi.R4type.rs2 == 0x0) // FCVT.S.W
-				dst.set_float((int32_t)rs1);
-			else // FCVT.S.WU
-				dst.set_float((uint32_t)rs1);
-			return;
+			switch (fi.R4type.rs2) {
+			case 0x0: dst.set_float((int32_t)rs1); return; // FCVT.S.W
+			case 0x1: dst.set_float((uint32_t)rs1); return; // FCVT.S.WU
+			case 0x2: dst.set_float((int64_t)rs1); return; // FCVT.S.L
+			case 0x3: dst.set_float((uint64_t)rs1); return; // FCVT.S.LU
+			}
+			break;
 		case 0x1: // to float64
 			switch (fi.R4type.rs2) {
 			case 0x0: // FCVT.D.W

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1951,9 +1951,13 @@ void Emitter<W>::emit()
 				} break;
 			case RV32F__FCVT_SD_W: {
 				if (fi.R4type.funct2 == 0x0) {
-					// FCVT.S.W && FCVT.S.WU
-					const std::string sign((fi.R4type.rs2 == 0x0) ? "(int32_t)" : "(uint32_t)");
-					code += "set_fl(&" + dst + ", " + sign + from_reg(fi.R4type.rs1) + ");\n";
+					switch (fi.R4type.rs2) {
+					case 0x0: code += "set_fl(&" + dst + ", (int32_t)" + from_reg(fi.R4type.rs1) + ");\n"; break;
+					case 0x1: code += "set_fl(&" + dst + ", (uint32_t)" + from_reg(fi.R4type.rs1) + ");\n"; break;
+					case 0x2: code += "set_fl(&" + dst + ", (int64_t)" + from_reg(fi.R4type.rs1) + ");\n"; break;
+					case 0x3: code += "set_fl(&" + dst + ", (uint64_t)" + from_reg(fi.R4type.rs1) + ");\n"; break;
+					default: UNKNOWN_INSTRUCTION();
+					}
 				} else if (fi.R4type.funct2 == 0x1) {
 					// FCVT.D.[LWU]
 					switch (fi.R4type.rs2) {


### PR DESCRIPTION
Fixes #359

Handle the L and LU source-width encodings in the `FCVT.S.*` interpreter and translated lowering, using signed and unsigned 64-bit casts respectively.

Changed files: `lib/libriscv/rvf_instr.cpp` and `lib/libriscv/tr_emit.cpp`.