### PR TITLE
Canonicalize NaN results of cross-precision FCVT

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -569,10 +569,16 @@ namespace riscv
 		auto& dst = cpu.registers().getfl(fi.R4type.rd);
 		switch (fi.R4type.funct2) {
 		case 0x0: // FCVT.S.D (64 -> 32)
-			dst.set_float(rs1.f64);
+			if (std::isnan(rs1.f64))
+				dst.load_u32(CANONICAL_NAN_F32);
+			else
+				dst.set_float(rs1.f64);
 			break;
 		case 0x1: // FCVT.D.S (32 -> 64)
-			dst.f64 = rs1.f32[0];
+			if (std::isnan(rs1.f32[0]))
+				dst.load_u64(CANONICAL_NAN_F64);
+			else
+				dst.f64 = rs1.f32[0];
 			break;
 		default:
 			cpu.trigger_exception(ILLEGAL_OPERATION);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1943,9 +1943,9 @@ void Emitter<W>::emit()
 				} break;
 			case RV32F__FCVT_SD_DS:
 				if (fi.R4type.funct2 == 0x0) {
-					code += "set_fl(&" + dst + ", " + rs1 + ".f64);\n";
+					code += "if (" + rs1 + ".f64 != " + rs1 + ".f64) load_fl(&" + dst + ", 0x7fc00000u); else set_fl(&" + dst + ", " + rs1 + ".f64);\n";
 				} else if (fi.R4type.funct2 == 0x1) {
-					code += "set_dbl(&" + dst + ", " + rs1 + ".f32[0]);\n";
+					code += "if (" + rs1 + ".f32[0] != " + rs1 + ".f32[0]) load_dbl(&" + dst + ", 0x7ff8000000000000ull); else set_dbl(&" + dst + ", " + rs1 + ".f32[0]);\n";
 				} else {
 					UNKNOWN_INSTRUCTION();
 				} break;


### PR DESCRIPTION
Fixes #360

Write the canonical NaN result for NaN inputs to `FCVT.S.D` and `FCVT.D.S` in both the interpreter and translated lowering.

Changed files: `lib/libriscv/rvf_instr.cpp` and `lib/libriscv/tr_emit.cpp`.