### PR TITLE
NaN-box RV64 single-precision results

### DIFF
--- a/lib/libriscv/registers.hpp
+++ b/lib/libriscv/registers.hpp
@@ -26,23 +26,18 @@ namespace riscv
 		} usign;
 
 		inline void nanbox() {
-			if constexpr (fcsr_emulation)
-				this->i32[1] = ~0;
-			else
-				this->i32[1] = 0;
+			this->i32[1] = ~0;
 		}
 		void set_float(float f) {
 			this->f32[0] = f;
-			if constexpr (nanboxing)
-				this->nanbox();
+			this->nanbox();
 		}
 		void set_double(double d) {
 			this->f64 = d;
 		}
 		void load_u32(uint32_t val) {
 			this->i32[0] = val;
-			if constexpr (nanboxing)
-				this->nanbox();
+			this->nanbox();
 		}
 		void load_u64(uint64_t val) {
 			this->i64 = val;

--- a/lib/libriscv/tr_api.cpp
+++ b/lib/libriscv/tr_api.cpp
@@ -226,13 +226,13 @@ typedef union {
 #ifdef RISCV_NANBOXING
 #define load_fl(reg, iv) \
 	(reg)->i32[0] = (iv);
-	(reg)->i32[1] = 0;
+	(reg)->i32[1] = ~0u;
 #define set_fl(reg, fv) \
 	(reg)->f32[0] = (fv);
-	(reg)->i32[1] = 0;
+	(reg)->i32[1] = ~0u;
 #else
-#define load_fl(reg, fv) (reg)->i32[0] = (fv)
-#define set_fl(reg, fv)  (reg)->f32[0] = (fv)
+#define load_fl(reg, iv) do { (reg)->i32[0] = (iv); (reg)->i32[1] = ~0u; } while (0)
+#define set_fl(reg, fv)  do { (reg)->f32[0] = (fv); (reg)->i32[1] = ~0u; } while (0)
 #endif
 
 #define load_dbl(reg, dv) (reg)->i64 = (dv)


### PR DESCRIPTION
Fixes #361

Set bits 63:32 when interpreter and translated helper paths write a single-precision value to an RV64 floating-point register.

Changed files: `lib/libriscv/registers.hpp` and `lib/libriscv/tr_api.cpp`.