### PR TITLE
Set NX for inexact FCVT.S.W and FCVT.D.L

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -669,9 +669,17 @@ namespace riscv
 		switch (fi.R4type.funct2) {
 		case 0x0: // to float32
 			switch (fi.R4type.rs2) {
-			case 0x0: // FCVT.S.W
-				dst.set_float((int32_t)rs1);
+			case 0x0: { // FCVT.S.W
+				const int32_t value = rs1;
+				dst.set_float(value);
+				const uint32_t magnitude = value < 0 ? 0u - (uint32_t)value : (uint32_t)value;
+				if constexpr (fcsr_emulation) {
+					unsigned bits = 0;
+					for (uint32_t n = magnitude; n != 0; n >>= 1) ++bits;
+					if (bits > 24 && (magnitude & ((1u << (bits - 24)) - 1))) cpu.registers().fcsr().fflags |= 1;
+				}
 				return;
+			}
 			case 0x1: // FCVT.S.WU
 				dst.set_float((uint32_t)rs1);
 				return;
@@ -692,7 +700,13 @@ namespace riscv
 				dst.f64 = (uint32_t)rs1;
 				return;
 			case 0x2: // FCVT.D.L
-				dst.f64 = (int64_t)rs1;
+				{ const int64_t value = rs1; dst.f64 = value;
+				const uint64_t magnitude = value < 0 ? 0ull - (uint64_t)value : (uint64_t)value;
+				if constexpr (fcsr_emulation) {
+					unsigned bits = 0;
+					for (uint64_t n = magnitude; n != 0; n >>= 1) ++bits;
+					if (bits > 53 && (magnitude & ((1ull << (bits - 53)) - 1))) cpu.registers().fcsr().fflags |= 1;
+				} }
 				return;
 			case 0x3: // FCVT.D.LU
 				dst.f64 = (uint64_t)rs1;

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -2039,7 +2039,7 @@ void Emitter<W>::emit()
 					// FCVT.S.[LWU]
 					switch (fi.R4type.rs2) {
 					case 0x0: // FCVT.S.W
-						code += "set_fl(&" + dst + ", (int32_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						code += "{ int32_t v = (int32_t)" + from_reg(fi.R4type.rs1) + "; uint32_t m = v < 0 ? 0u - (uint32_t)v : (uint32_t)v; unsigned b = m ? 32u - api.clz(m) : 0; if (b > 24u && (m & ((1u << (b - 24u)) - 1))) cpu->fcsr |= 1; set_fl(&" + dst + ", v); }\n";
 						break;
 					case 0x1: // FCVT.S.WU
 						code += "set_fl(&" + dst + ", (uint32_t)" + from_reg(fi.R4type.rs1) + ");\n";
@@ -2063,7 +2063,7 @@ void Emitter<W>::emit()
 						code += "set_dbl(&" + dst + ", (uint32_t)" + from_reg(fi.R4type.rs1) + ");\n";
 						break;
 					case 0x2: // FCVT.D.L
-						code += "set_dbl(&" + dst + ", (int64_t)" + from_reg(fi.R4type.rs1) + ");\n";
+						code += "{ int64_t v = (int64_t)" + from_reg(fi.R4type.rs1) + "; uint64_t m = v < 0 ? 0ull - (uint64_t)v : (uint64_t)v; unsigned b = m ? 64u - api.clzl(m) : 0; if (b > 53u && (m & ((1ull << (b - 53u)) - 1))) cpu->fcsr |= 1; set_dbl(&" + dst + ", v); }\n";
 						break;
 					case 0x3: // FCVT.D.LU
 						code += "set_dbl(&" + dst + ", (uint64_t)" + from_reg(fi.R4type.rs1) + ");\n";


### PR DESCRIPTION
Fixes #362

Set NX when `FCVT.S.W` or `FCVT.D.L` discards nonzero integer bits while rounding to the destination precision. The interpreter and translated lowering use the same bit-level check.

Changed files: `lib/libriscv/rvf_instr.cpp` and `lib/libriscv/tr_emit.cpp`.