### PR TITLE
floating point: canonicalize quiet-NaN FADD.S results

### DIFF
--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -521,7 +521,19 @@ INSTRUCTION(RV32F_BC_FADD, rv32f_fadd) {
 	FLREGS();
 	if (fi.func == 0x0)
 	{ // float32
-		dst.set_float(rs1.f32[0] + rs2.f32[0]);
+		const uint32_t a = rs1.i32[0];
+		const uint32_t b = rs2.i32[0];
+		const bool qnan = ((a & 0x7fc00000u) == 0x7fc00000u)
+			|| ((b & 0x7fc00000u) == 0x7fc00000u);
+		const bool snan = (((a & 0x7fc00000u) == 0x7f800000u)
+			&& (a & 0x003fffffu) != 0)
+			|| (((b & 0x7fc00000u) == 0x7f800000u)
+			&& (b & 0x003fffffu) != 0);
+		if (qnan && !snan) {
+			dst.load_u32(0x7fc00000u);
+		} else {
+			dst.set_float(rs1.f32[0] + rs2.f32[0]);
+		}
 	}
 	else
 	{ // float64

--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -278,8 +278,13 @@ namespace riscv
 		auto& rs1 = cpu.registers().getfl(fi.R4type.rs1);
 		auto& rs2 = cpu.registers().getfl(fi.R4type.rs2);
 		if (fi.R4type.funct2 == 0x0) { // float32
-			dst.set_float(rs1.f32[0] + rs2.f32[0]);
-			fsflags(cpu, (double)(rs1.f32[0]) + (double)(rs2.f32[0]), dst.f32[0]);
+			if ((std::isnan(rs1.f32[0]) || std::isnan(rs2.f32[0]))
+				&& !is_signaling_nan(rs1.f32[0]) && !is_signaling_nan(rs2.f32[0])) {
+				dst.load_u32(CANONICAL_NAN_F32);
+			} else {
+				dst.set_float(rs1.f32[0] + rs2.f32[0]);
+				fsflags(cpu, (double)(rs1.f32[0]) + (double)(rs2.f32[0]), dst.f32[0]);
+			}
 		} else if (fi.R4type.funct2 == 0x1) { // float64
 			dst.f64 = rs1.f64 + rs2.f64;
 			fsflags(cpu, (long double)(rs1.f64) + (long double)(rs2.f64), dst.f64);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1970,6 +1970,16 @@ void Emitter<W>::emit()
 					UNKNOWN_INSTRUCTION();
 				} break;
 			case RV32F__FADD:
+				if (fi.R4type.funct2 == 0x0) {
+					const std::string a = rs1 + ".i32[0]";
+					const std::string b = rs2 + ".i32[0]";
+					const std::string qnan = "(((" + a + " & 0x7fc00000u) == 0x7fc00000u) || ((" + b + " & 0x7fc00000u) == 0x7fc00000u))";
+					const std::string snan = "((((" + a + " & 0x7fc00000u) == 0x7f800000u) && ((" + a + " & 0x003fffffu) != 0)) || (((" + b + " & 0x7fc00000u) == 0x7f800000u) && ((" + b + " & 0x003fffffu) != 0)))";
+					code += "if (" + qnan + " && !" + snan + ") load_fl(&" + dst + ", 0x7fc00000u); else set_fl(&" + dst + ", " + rs1 + ".f32[0] + " + rs2 + ".f32[0]);\n";
+				} else {
+					code += "set_dbl(&" + dst + ", " + rs1 + ".f64 + " + rs2 + ".f64);\n";
+				}
+				break;
 			case RV32F__FSUB:
 			case RV32F__FMUL: {
 				std::string fop = " + ";


### PR DESCRIPTION
Fixes #368

Canonicalize quiet-NaN FADD.S results in the interpreter, bytecode dispatcher, and translated lowering. The quiet-NaN path leaves accrued flags unchanged; non-NaN and signaling-NaN handling is unchanged.