### PR TITLE
floating point: set DZ for FDIV.S by zero

### DIFF
--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -560,7 +560,14 @@ INSTRUCTION(RV32F_BC_FDIV, rv32f_fdiv) {
 	FLREGS();
 	if (fi.func == 0x0)
 	{ // float32
+		const bool divide_by_zero = (rs1.i32[0] & 0x7fffffffu) != 0
+			&& (rs1.i32[0] & 0x7f800000u) != 0x7f800000u
+			&& (rs2.i32[0] & 0x7fffffffu) == 0;
 		dst.set_float(rs1.f32[0] / rs2.f32[0]);
+		if constexpr (fcsr_emulation) {
+			if (divide_by_zero)
+				CPU().registers().fcsr().fflags |= 8;
+		}
 	}
 	else
 	{ // float64

--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -362,8 +362,17 @@ namespace riscv
 		auto& rs1 = cpu.registers().getfl(fi.R4type.rs1);
 		auto& rs2 = cpu.registers().getfl(fi.R4type.rs2);
 		if (fi.R4type.funct2 == 0x0) { // fp32
+			const bool divide_by_zero = (rs1.i32[0] & 0x7fffffffu) != 0
+				&& (rs1.i32[0] & 0x7f800000u) != 0x7f800000u
+				&& (rs2.i32[0] & 0x7fffffffu) == 0;
 			dst.set_float(rs1.f32[0] / rs2.f32[0]);
 			fsflags(cpu, (double)(rs1.f32[0]) / (double)(rs2.f32[0]), dst.f32[0]);
+#ifdef RISCV_FCSR
+			if constexpr (fcsr_emulation) {
+				if (divide_by_zero)
+					cpu.registers().fcsr().fflags |= 8;
+			}
+#endif
 		} else if (fi.R4type.funct2 == 0x1) { // fp64
 			dst.f64 = rs1.f64 / rs2.f64;
 			fsflags(cpu, (long double)(rs1.f64) / (long double)(rs2.f64), dst.f64);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1983,7 +1983,10 @@ void Emitter<W>::emit()
 				} break;
 			case RV32F__FDIV:
 				if (fi.R4type.funct2 == 0x0) { // fp32
-					code += "set_fl(&" + dst + ", " + rs1 + ".f32[0] / " + rs2 + ".f32[0]);\n";
+					const std::string a = rs1 + ".i32[0]";
+					const std::string b = rs2 + ".i32[0]";
+					const std::string dz = "(((" + a + " & 0x7fffffffu) != 0) && ((" + a + " & 0x7f800000u) != 0x7f800000u) && ((" + b + " & 0x7fffffffu) == 0))";
+					code += "set_fl(&" + dst + ", " + rs1 + ".f32[0] / " + rs2 + ".f32[0]); if (" + dz + ") cpu->fcsr |= 8;\n";
 					this->penalty(10); // divf is a slow operation
 				} else { // fp64
 					code += "set_dbl(&" + dst + ", " + rs1 + ".f64 / " + rs2 + ".f64);\n";


### PR DESCRIPTION
Fixes #369

Recognize the finite-nonzero divided-by-zero condition in FDIV.S and accumulate DZ in the interpreter, bytecode dispatcher, and translated lowering. Other divide classifications are unchanged.