### PR TITLE
floating point: preserve FMUL.S range flags

### DIFF
--- a/lib/libriscv/bytecode_impl.cpp
+++ b/lib/libriscv/bytecode_impl.cpp
@@ -547,7 +547,18 @@ INSTRUCTION(RV32F_BC_FMUL, rv32f_fmul) {
 	FLREGS();
 	if (fi.func == 0x0)
 	{ // float32
+		const bool finite_inputs = (rs1.i32[0] & 0x7f800000u) != 0x7f800000u
+			&& (rs2.i32[0] & 0x7f800000u) != 0x7f800000u;
 		dst.set_float(rs1.f32[0] * rs2.f32[0]);
+		if constexpr (fcsr_emulation) {
+			const uint32_t result = dst.i32[0] & 0x7fffffffu;
+			if (finite_inputs && (result & 0x7f800000u) == 0x7f800000u
+				&& (result & 0x007fffffu) == 0)
+				CPU().registers().fcsr().fflags |= 5;
+			else if (finite_inputs && result < 0x00800000u
+				&& (double)rs1.f32[0] * (double)rs2.f32[0] != dst.f32[0])
+				CPU().registers().fcsr().fflags |= 3;
+		}
 	}
 	else
 	{ // float64

--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -334,8 +334,21 @@ namespace riscv
 		auto& rs1 = cpu.registers().getfl(fi.R4type.rs1);
 		auto& rs2 = cpu.registers().getfl(fi.R4type.rs2);
 		if (fi.R4type.funct2 == 0x0) { // float32
+			const bool finite_inputs = (rs1.i32[0] & 0x7f800000u) != 0x7f800000u
+				&& (rs2.i32[0] & 0x7f800000u) != 0x7f800000u;
 			dst.set_float(rs1.f32[0] * rs2.f32[0]);
 			fsflags(cpu, (double)(rs1.f32[0]) * (double)(rs2.f32[0]), dst.f32[0]);
+#ifdef RISCV_FCSR
+			if constexpr (fcsr_emulation) {
+				const uint32_t result = dst.i32[0] & 0x7fffffffu;
+				if (finite_inputs && (result & 0x7f800000u) == 0x7f800000u
+					&& (result & 0x007fffffu) == 0)
+					cpu.registers().fcsr().fflags |= 4;
+				else if (finite_inputs && result < 0x00800000u
+					&& (double)rs1.f32[0] * (double)rs2.f32[0] != dst.f32[0])
+					cpu.registers().fcsr().fflags |= 2;
+			}
+#endif
 		} else if (fi.R4type.funct2 == 0x1) { // float64
 			dst.f64 = rs1.f64 * rs2.f64;
 			fsflags(cpu, (long double)(rs1.f64) * (long double)(rs2.f64), dst.f64);

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -1970,17 +1970,26 @@ void Emitter<W>::emit()
 					UNKNOWN_INSTRUCTION();
 				} break;
 			case RV32F__FADD:
-			case RV32F__FSUB:
-			case RV32F__FMUL: {
+			case RV32F__FSUB: {
 				std::string fop = " + ";
 				if (instr.fpfunc() == RV32F__FSUB) fop = " - ";
-				else if (instr.fpfunc() == RV32F__FMUL) fop = " * ";
 				if (fi.R4type.funct2 == 0x0) { // fp32
 					code += "set_fl(&" + dst + ", " + rs1 + ".f32[0]" + fop + rs2 + ".f32[0]);\n";
 				} else { // fp64
 					code += "set_dbl(&" + dst + ", " + rs1 + ".f64" + fop + rs2 + ".f64);\n";
 				}
 				} break;
+			case RV32F__FMUL:
+				if (fi.R4type.funct2 == 0x0) {
+					const std::string a = rs1 + ".i32[0]";
+					const std::string b = rs2 + ".i32[0]";
+					const std::string result = dst + ".i32[0]";
+					const std::string finite = "(((" + a + " & 0x7f800000u) != 0x7f800000u) && ((" + b + " & 0x7f800000u) != 0x7f800000u))";
+					code += "{ const float result = " + rs1 + ".f32[0] * " + rs2 + ".f32[0]; set_fl(&" + dst + ", result); if (" + finite + ") { if (((" + result + " & 0x7fffffffu) & 0x7f800000u) == 0x7f800000u && ((" + result + " & 0x007fffffu) == 0)) cpu->fcsr |= 5; else if ((" + result + " & 0x7fffffffu) < 0x00800000u && (double)" + rs1 + ".f32[0] * (double)" + rs2 + ".f32[0] != result) cpu->fcsr |= 3; } }\n";
+				} else {
+					code += "set_dbl(&" + dst + ", " + rs1 + ".f64 * " + rs2 + ".f64);\n";
+				}
+				break;
 			case RV32F__FDIV:
 				if (fi.R4type.funct2 == 0x0) { // fp32
 					code += "set_fl(&" + dst + ", " + rs1 + ".f32[0] / " + rs2 + ".f32[0]);\n";


### PR DESCRIPTION
Fixes #370

Classify finite FMUL.S results that overflow to infinity or underflow to a tiny inexact result, and record OF|NX or UF|NX in every execution path. The multiplication itself is unchanged.