### PR TITLE
floating point: clip invalid FCVT.W.S results

### DIFF
--- a/lib/libriscv/rvf_instr.cpp
+++ b/lib/libriscv/rvf_instr.cpp
@@ -9,24 +9,28 @@ namespace riscv
 	static constexpr uint64_t CANONICAL_NAN_F64 = 0x7ff8000000000000;
 
 	// Round a float/double per the RISC-V rounding mode (funct3 of the FCVT
-	// instruction) and convert to the destination integer type T. The plain
-	// C++ cast used previously only implements RTZ (truncation), which is wrong
-	// for the round-to-nearest modes used by e.g. std::lround/std::rint.
-	template <typename T, typename F>
-	static inline T fcvt_to_integer(F value, unsigned rm) {
+	// instruction).
+	template <typename F>
+	static inline F fcvt_round(F value, unsigned rm) {
 		switch (rm) {
 		case 0x1: // RTZ: round toward zero
-			return T(std::trunc(value));
+			return std::trunc(value);
 		case 0x2: // RDN: round down (toward -inf)
-			return T(std::floor(value));
+			return std::floor(value);
 		case 0x3: // RUP: round up (toward +inf)
-			return T(std::ceil(value));
+			return std::ceil(value);
 		case 0x4: // RMM: round to nearest, ties away from zero
-			return T(std::round(value));
+			return std::round(value);
 		case 0x0: // RNE: round to nearest, ties to even
 		default:  // reserved/invalid modes: nearest-even as the default
-			return T(std::nearbyint(value));
+			return std::nearbyint(value);
 		}
+	}
+
+	// Convert a rounded floating-point value to the destination integer type.
+	template <typename T, typename F>
+	static inline T fcvt_to_integer(F value, unsigned rm) {
+		return T(fcvt_round(value, rm));
 	}
 
 	// A signaling NaN has an all-ones exponent, a clear quiet bit and a non-zero
@@ -617,12 +621,34 @@ namespace riscv
 		switch (fi.R4type.funct2) {
 		case 0x0: // from float32
 			switch (fi.R4type.rs2) {
-			case 0x0: // FCVT.W.S
-				dst = fcvt_to_integer<int32_t>(rs1.f32[0], rmm);
+			case 0x0: { // FCVT.W.S
+				const float rounded = fcvt_round(rs1.f32[0], rmm);
+				if (std::isnan(rounded) || rounded < -2147483648.0f || rounded >= 2147483648.0f) {
+					dst = (std::isnan(rounded) || rounded >= 2147483648.0f)
+						? int32_t(2147483647) : int32_t(-2147483647 - 1);
+#ifdef RISCV_FCSR
+					if constexpr (fcsr_emulation)
+						cpu.registers().fcsr().fflags |= 16;
+#endif
+				} else {
+					dst = int32_t(rounded);
+				}
 				return;
-			case 0x1: // FCVT.WU.S (sign-extended 32-bit result)
-				dst = int32_t(fcvt_to_integer<uint32_t>(rs1.f32[0], rmm));
+			}
+			case 0x1: { // FCVT.WU.S (sign-extended 32-bit result)
+				const float rounded = fcvt_round(rs1.f32[0], rmm);
+				if (std::isnan(rounded) || rounded < 0.0f || rounded >= 4294967296.0f) {
+					dst = int32_t((std::isnan(rounded) || rounded >= 4294967296.0f)
+						? 0xffffffffu : 0u);
+#ifdef RISCV_FCSR
+					if constexpr (fcsr_emulation)
+						cpu.registers().fcsr().fflags |= 16;
+#endif
+				} else {
+					dst = int32_t(uint32_t(rounded));
+				}
 				return;
+			}
 			case 0x2: // FCVT.L.S
 				dst = fcvt_to_integer<int64_t>(rs1.f32[0], rmm);
 				return;

--- a/lib/libriscv/tr_emit.cpp
+++ b/lib/libriscv/tr_emit.cpp
@@ -2116,10 +2116,18 @@ void Emitter<W>::emit()
 					std::string expr;
 					switch (fi.R4type.rs2) {
 					case 0x0: // FCVT.W (int32, sign-extended)
-						expr = "(int32_t)" + rounded;
+						if (from_float) {
+							code += "{ const float rounded = " + rounded + "; if (rounded != rounded || rounded < -2147483648.0f || rounded >= 2147483648.0f) { " + to_reg(fi.R4type.rd) + " = (rounded != rounded || rounded >= 2147483648.0f) ? 2147483647 : (-2147483647 - 1); cpu->fcsr |= 16; } else " + to_reg(fi.R4type.rd) + " = (int32_t)rounded; }\n";
+						} else {
+							expr = "(int32_t)" + rounded;
+						}
 						break;
 					case 0x1: // FCVT.WU (uint32 result, sign-extended to XLEN)
-						expr = "(int32_t)(uint32_t)" + rounded;
+						if (from_float) {
+							code += "{ const float rounded = " + rounded + "; if (rounded != rounded || rounded < 0.0f || rounded >= 4294967296.0f) { " + to_reg(fi.R4type.rd) + " = (int32_t)((rounded != rounded || rounded >= 4294967296.0f) ? 0xffffffffu : 0u); cpu->fcsr |= 16; } else " + to_reg(fi.R4type.rd) + " = (int32_t)(uint32_t)rounded; }\n";
+						} else {
+							expr = "(int32_t)(uint32_t)" + rounded;
+						}
 						break;
 					case 0x2: // FCVT.L (int64)
 						expr = "(int64_t)" + rounded;
@@ -2132,7 +2140,7 @@ void Emitter<W>::emit()
 					}
 					if (!expr.empty())
 						code += to_reg(fi.R4type.rd) + " = " + expr + ";\n";
-					else
+					else if (!from_float || fi.R4type.rs2 > 1)
 						UNKNOWN_INSTRUCTION();
 				} else {
 					UNKNOWN_INSTRUCTION();


### PR DESCRIPTION
Fixes #372

Check rounded FCVT.W.S and FCVT.WU.S values before casting. Invalid inputs now return the specified clipped result and set NV in both interpreter and translated execution.